### PR TITLE
Spelling correction in description of Core.Link

### DIFF
--- a/vocabularies/Org.OData.Core.V1.xml
+++ b/vocabularies/Org.OData.Core.V1.xml
@@ -120,7 +120,7 @@
       </Term>
       <ComplexType Name="Link">
         <Annotation Term="Core.Description"
-          String="The Link term is inspired by the `atom:link` element, see [RFC4287](https://tools.ietf.org/html/rfc4287#section-4.2.7) and the `Link` HTTP header, see [RFC5988](https://tools.ietf.org/html/rfc5988)" />
+          String="The Link term is inspired by the `atom:link` element, see [RFC4287](https://tools.ietf.org/html/rfc4287#section-4.2.7), and the `Link` HTTP header, see [RFC5988](https://tools.ietf.org/html/rfc5988)" />
         <Property Name="rel" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description"
             String="Link relation type, see [IANA Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml)" />


### PR DESCRIPTION
Added a missing comma in the description of ComplexType Core.Link