### PR TITLE
ODATA-1318 - resolved - Fix issues with Capabilities vocabulary

### DIFF
--- a/examples/Org.OData.Capabilities.V1.permissions-sample.xml
+++ b/examples/Org.OData.Capabilities.V1.permissions-sample.xml
@@ -8,7 +8,7 @@
       <Annotations Target="microsoft.graph.GraphService/users">
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
-            <PropertyValue Property="Permissions">
+            <PropertyValue Property="Permission">
               <Collection>
                 <Record>
                   <PropertyValue Property="Scheme" String="DelegatedWork" />
@@ -64,7 +64,7 @@
         </Annotation>
         <Annotation Term="Capabilities.UpdateRestrictions">
           <Record>
-            <PropertyValue Property="Permissions">
+            <PropertyValue Property="Permission">
               <Collection>
                 <Record>
                   <PropertyValue Property="Scheme" String="DelegatedWork" />
@@ -115,7 +115,7 @@
         <!-- Read restrictions :select restrictions and then props to filter, expand, etc. -->
         <Annotation Term="Capabilities.ReadRestrictions">
           <Record>
-            <PropertyValue Property="Permissions">
+            <PropertyValue Property="Permission">
               <Collection>
                 <Record>
                   <PropertyValue Property="Scheme" String="DelegatedWork" />
@@ -179,7 +179,7 @@
       <Annotations Target="microsoft.graph.reminderView(microsoft.graph.user,Edm.String,Edm.String)">
         <Annotation Term="Capabilities.OperationRestrictions">
             <Record>
-              <PropertyValue Property="Permissions">
+              <PropertyValue Property="Permission">
                 <Record>
                   <PropertyValue Property="Scheme" String="DelegatedWork" />
                   <PropertyValue Property="Scopes">

--- a/examples/Org.OData.Capabilities.V1.permissions-sample.xml
+++ b/examples/Org.OData.Capabilities.V1.permissions-sample.xml
@@ -175,9 +175,7 @@
       <Annotations Target="microsoft.graph.reminderView(microsoft.graph.user,Edm.String,Edm.String)">
         <!-- for a path that looks like "GET /users/{id | userPrincipalName}/reminderView(startDateTime=startDateTime-value,endDateTime=endDateTime-value)" -->
         <Annotation Term="Capabilities.OperationRestrictions">
-          <Collection>
             <Record>
-              <PropertyValue Property="QualifiedOperationName" String="reminderView" />
               <PropertyValue Property="Permissions">
                 <Record>
                   <PropertyValue Property="Scheme" String="DelegatedWork" />
@@ -220,7 +218,6 @@
                 </Record>
               </PropertyValue>
             </Record>
-          </Collection>
         </Annotation>
       </Annotations>
       <!-- Annotating container with Auth Schemes that contain all the scopes applicable per that security scheme. Graph has 3 security schemes,

--- a/examples/Org.OData.Capabilities.V1.permissions-sample.xml
+++ b/examples/Org.OData.Capabilities.V1.permissions-sample.xml
@@ -9,102 +9,106 @@
         <Annotation Term="Capabilities.InsertRestrictions">
           <Record>
             <PropertyValue Property="Permissions">
-              <Record>
-                <PropertyValue Property="Scheme" String="DelegatedWork" />
-                <PropertyValue Property="Scopes">
-                  <Collection>
-                    <Record>
-                      <PropertyValue Property="Scope" String="User.ReadWrite.All" />
-                      <!--
-                        * , [PROPERTY NAME], - list
-                        "*" denotes all properties are accessible
-                        "Property name" used to provide access to specific properties
-                        "-" sign prepended to property name used to exclude specific properties
-                        Absence of the PropertyValue denotes all properties are accessible using that scope.
-                      -->
-                      <PropertyValue Property="RestrictedProperties">
-                        <String>-mailboxSettings</String>
-                      </PropertyValue>
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="MailboxSettings.ReadWrite" />
-                      <PropertyValue Property="RestrictedProperties">
-                        <String>mailboxSettings</String>
-                      </PropertyValue>
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
-                    </Record>
-                  </Collection>
-                </PropertyValue>
-              </Record>
-              <Record>
-                <PropertyValue Property="Scheme" String="Application" />
-                <PropertyValue Property="Scopes">
-                  <Collection>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="MailboxSettings.ReadWrite" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
-                    </Record>
-                  </Collection>
-                </PropertyValue>
-              </Record>
+              <Collection>
+                <Record>
+                  <PropertyValue Property="Scheme" String="DelegatedWork" />
+                  <PropertyValue Property="Scopes">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property="Scope" String="User.ReadWrite.All" />
+                        <!--
+                          * , [PROPERTY NAME], - list
+                          "*" denotes all properties are accessible
+                          "Property name" used to provide access to specific properties
+                          "-" sign prepended to property name used to exclude specific properties
+                          Absence of the PropertyValue denotes all properties are accessible using that scope.
+                        -->
+                        <PropertyValue Property="RestrictedProperties">
+                          <String>-mailboxSettings</String>
+                        </PropertyValue>
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="MailboxSettings.ReadWrite" />
+                        <PropertyValue Property="RestrictedProperties">
+                          <String>mailboxSettings</String>
+                        </PropertyValue>
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+                <Record>
+                  <PropertyValue Property="Scheme" String="Application" />
+                  <PropertyValue Property="Scopes">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="MailboxSettings.ReadWrite" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+              </Collection>
             </PropertyValue>
           </Record>
         </Annotation>
         <Annotation Term="Capabilities.UpdateRestrictions">
           <Record>
             <PropertyValue Property="Permissions">
-              <Record>
-                <PropertyValue Property="Scheme" String="DelegatedWork" />
-                <PropertyValue Property="Scopes">
-                  <Collection>
-                    <Record>
-                      <PropertyValue Property="Scope" String="User.ReadWrite" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="User.ReadWrite.All" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
-                    </Record>
-                  </Collection>
-                </PropertyValue>
-              </Record>
-              <Record>
-                <PropertyValue Property="Scheme" String="DelegatedPersonal" />
-                <PropertyValue Property="Scopes">
-                  <Collection>
-                    <Record>
-                      <PropertyValue Property="Scope" String="User.ReadWrite" />
-                    </Record>
-                  </Collection>
-                </PropertyValue>
-              </Record>
-              <Record>
-                <PropertyValue Property="Scheme" String="Application" />
-                <PropertyValue Property="Scopes">
-                  <Collection>
-                    <Record>
-                      <PropertyValue Property="Scope" String="User.ReadWrite.All" />
-                    </Record>
-                    <Record>
-                      <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
-                    </Record>
-                  </Collection>
-                </PropertyValue>
-              </Record>
+              <Collection>
+                <Record>
+                  <PropertyValue Property="Scheme" String="DelegatedWork" />
+                  <PropertyValue Property="Scopes">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property="Scope" String="User.ReadWrite" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="User.ReadWrite.All" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.AccessAsUser.All" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+                <Record>
+                  <PropertyValue Property="Scheme" String="DelegatedPersonal" />
+                  <PropertyValue Property="Scopes">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property="Scope" String="User.ReadWrite" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+                <Record>
+                  <PropertyValue Property="Scheme" String="Application" />
+                  <PropertyValue Property="Scopes">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property="Scope" String="User.ReadWrite.All" />
+                      </Record>
+                      <Record>
+                        <PropertyValue Property="Scope" String="Directory.ReadWrite.All" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+              </Collection>
             </PropertyValue>
           </Record>
         </Annotation>
@@ -173,7 +177,6 @@
       </Annotations>
       <!-- annotations on actions/functions -->
       <Annotations Target="microsoft.graph.reminderView(microsoft.graph.user,Edm.String,Edm.String)">
-        <!-- for a path that looks like "GET /users/{id | userPrincipalName}/reminderView(startDateTime=startDateTime-value,endDateTime=endDateTime-value)" -->
         <Annotation Term="Capabilities.OperationRestrictions">
             <Record>
               <PropertyValue Property="Permissions">

--- a/vocabularies/Org.OData.Authorization.V1.xml
+++ b/vocabularies/Org.OData.Authorization.V1.xml
@@ -72,7 +72,7 @@
       </Term>
 
       <ComplexType Name="SecurityScheme">
-        <Property Name="Authorization" Type="Edm.String" Nullable="false">
+        <Property Name="Authorization" Type="Auth.SchemeName" Nullable="false">
           <Annotation Term="Core.Description" String="The name of a required authorization scheme" />
         </Property>
         <Property Name="RequiredScopes" Type="Collection(Edm.String)" Nullable="false">
@@ -187,6 +187,10 @@
           <Annotation Term="Core.Description" String="API Key is passed as a cookie" />
         </Member>
       </EnumType>
+
+      <TypeDefinition Name="SchemeName" UnderlyingType="Edm.String">
+          <Annotation Term="Core.Description" String="The name of the auth scheme." />
+      </TypeDefinition>
 
     </Schema>
   </edmx:DataServices>

--- a/vocabularies/Org.OData.Authorization.V1.xml
+++ b/vocabularies/Org.OData.Authorization.V1.xml
@@ -189,7 +189,7 @@
       </EnumType>
 
       <TypeDefinition Name="SchemeName" UnderlyingType="Edm.String">
-          <Annotation Term="Core.Description" String="The name of the auth scheme." />
+          <Annotation Term="Core.Description" String="The name of the authorization scheme." />
       </TypeDefinition>
 
     </Schema>

--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -600,7 +600,7 @@ supported:
             String="Entities of a specific derived type can be created by specifying a type-cast segment" />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
-          <Annotation Term="Core.Description" String="Required scopes to perform the insert" />
+          <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to perform the insert." />
         </Property>
         <Property Name="QueryOptions" Type="Capabilities.ModificationQueryOptionsType" Nullable="true">
           <Annotation Term="Core.Description" String="Support for query options with insert requests" />
@@ -695,7 +695,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
             String="The maximum number of navigation properties that can be traversed when addressing the collection or entity to update. A value of -1 indicates there is no restriction." />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
-          <Annotation Term="Core.Description" String="Required scopes to perform update" />
+          <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to perform the update." />
         </Property>
         <Property Name="QueryOptions" Type="Capabilities.ModificationQueryOptionsType" Nullable="true">
           <Annotation Term="Core.Description" String="Support for query options with update requests" />
@@ -753,7 +753,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
             String="Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment" />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
-          <Annotation Term="Core.Description" String="Required scopes to perform delete" />
+          <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to perform the delete." />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
           <Annotation Term="Core.Description" String="Supported or required custom headers" />
@@ -828,7 +828,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
             String="Bound action or function can be invoked on a collection-valued binding parameter path with a `/$filter(...)` segment" />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
-          <Annotation Term="Core.Description" String="List of required scopes to invoke an action or function" />
+          <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to invoke an action or function" />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
           <Annotation Term="Core.Description" String="Supported or required custom headers" />
@@ -877,7 +877,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="Entities can be retrieved" />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
-          <Annotation Term="Core.Description" String="List of required scopes to invoke an action or function" />
+          <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to read." />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
           <Annotation Term="Core.Description" String="Supported or required custom headers" />

--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -622,7 +622,7 @@ supported:
       </ComplexType>
 
       <ComplexType Name="PermissionType">
-        <Property Name="Scheme" Type="Auth.SecurityScheme" Nullable="false">
+        <Property Name="Scheme" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Auth flow scheme name" />
         </Property>
         <Property Name="Scopes" Type="Collection(Capabilities.ScopeType)" Nullable="false">
@@ -817,12 +817,12 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="OperationRestrictions" Type="Collection(Capabilities.OperationRestriction)" Nullable="false"
-        AppliesTo="Action Function"
+      <Term Name="OperationRestrictions" Type="Capabilities.OperationRestrictionsType" Nullable="false"
+        AppliesTo="Action ActionImport Function FunctionImport"
       >
         <Annotation Term="Core.Description" String="Restrictions for function or action operation" />
       </Term>
-      <ComplexType Name="OperationRestriction">
+      <ComplexType Name="OperationRestrictionsType">
         <Property Name="FilterSegmentSupported" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description"
             String="Bound action or function can be invoked on a collection-valued binding parameter path with a `/$filter(...)` segment" />
@@ -868,7 +868,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="ReadRestrictions" Type="Capabilities.ReadRestrictionsType" AppliesTo="EntitySet Singleton FunctionImport">
+      <Term Name="ReadRestrictions" Type="Capabilities.ReadRestrictionsType" AppliesTo="EntitySet Singleton">
         <Annotation Term="Core.Description"
           String="Restrictions for retrieving a collection of entities, retrieving a singleton instance, invoking a function" />
       </Term>

--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -599,7 +599,7 @@ supported:
           <Annotation Term="Core.Description"
             String="Entities of a specific derived type can be created by specifying a type-cast segment" />
         </Property>
-        <Property Name="Permission" Type="Capabilities.PermissionType" Nullable="true">
+        <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="Required scopes to perform the insert" />
         </Property>
         <Property Name="QueryOptions" Type="Capabilities.ModificationQueryOptionsType" Nullable="true">
@@ -622,7 +622,7 @@ supported:
       </ComplexType>
 
       <ComplexType Name="PermissionType">
-        <Property Name="Scheme" Type="Edm.String" Nullable="false">
+        <Property Name="SchemeName" Type="Auth.SchemeName" Nullable="false">
           <Annotation Term="Core.Description" String="Auth flow scheme name" />
         </Property>
         <Property Name="Scopes" Type="Collection(Capabilities.ScopeType)" Nullable="false">
@@ -694,7 +694,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description"
             String="The maximum number of navigation properties that can be traversed when addressing the collection or entity to update. A value of -1 indicates there is no restriction." />
         </Property>
-        <Property Name="Permission" Type="Capabilities.PermissionType" Nullable="true">
+        <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="Required scopes to perform update" />
         </Property>
         <Property Name="QueryOptions" Type="Capabilities.ModificationQueryOptionsType" Nullable="true">
@@ -752,7 +752,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description"
             String="Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment" />
         </Property>
-        <Property Name="Permission" Type="Capabilities.PermissionType" Nullable="true">
+        <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="Required scopes to perform delete" />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
@@ -818,7 +818,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
       </ComplexType>
 
       <Term Name="OperationRestrictions" Type="Capabilities.OperationRestrictionsType" Nullable="false"
-        AppliesTo="Action ActionImport Function FunctionImport"
+        AppliesTo="Action Function"
       >
         <Annotation Term="Core.Description" String="Restrictions for function or action operation" />
       </Term>
@@ -827,7 +827,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description"
             String="Bound action or function can be invoked on a collection-valued binding parameter path with a `/$filter(...)` segment" />
         </Property>
-        <Property Name="Permission" Type="Capabilities.PermissionType" Nullable="true">
+        <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="List of required scopes to invoke an action or function" />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
@@ -876,7 +876,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         <Property Name="Readable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="Entities can be retrieved" />
         </Property>
-        <Property Name="Permission" Type="Capabilities.PermissionType" Nullable="true">
+        <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="List of required scopes to invoke an action or function" />
         </Property>
         <Property Name="CustomHeaders" Type="Collection(Capabilities.CustomParameter)" Nullable="false">

--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -623,7 +623,7 @@ supported:
 
       <ComplexType Name="PermissionType">
         <Property Name="SchemeName" Type="Auth.SchemeName" Nullable="false">
-          <Annotation Term="Core.Description" String="Auth flow scheme name" />
+          <Annotation Term="Core.Description" String="Authorization flow scheme name" />
         </Property>
         <Property Name="Scopes" Type="Collection(Capabilities.ScopeType)" Nullable="false">
           <Annotation Term="Core.Description" String="List of scopes that can provide access to the resource" />

--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -870,7 +870,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
 
       <Term Name="ReadRestrictions" Type="Capabilities.ReadRestrictionsType" AppliesTo="EntitySet Singleton">
         <Annotation Term="Core.Description"
-          String="Restrictions for retrieving a collection of entities, retrieving a singleton instance, invoking a function" />
+          String="Restrictions for retrieving a collection of entities, retrieving a singleton instance." />
       </Term>
       <ComplexType Name="ReadRestrictionsBase" Abstract="true">
         <Property Name="Readable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">


### PR DESCRIPTION
- Updated the capabilities.xml to change property `Scheme' under complex type `PermissionType` to be of type 'Edm.String'.

  This was causing us to render the entire Auth.Scheme node as a nested element inside the Read/Insert/Update/Delete Restrictions. The change to Edm.String will allow naming the AuthScheme that is available and targeted at the container. Auth schemes defined at the container level contain properties such as `authurl`, `refreshurl`, etc. from the auth vocabulary.

- Updated `OperationRestrictions` to remove 'Collection'. It should be only a single record of `Capabilities.OperationRestrictionsType`.

  OperationRestrictions does not need to be a collection type since we have no way to identify the parameters (in case of overload) for which this would be a collection. There is already a mechanism that exists to create annotations to target specific overloads, so collection is needless.

- Renamed `OperationRestrictions` to `OperationRestrictionsType` to be consistent with naming conventions in the vocabulary.

- Removed `FunctionImport` from ReadRestrictions.  

  FunctionImport has been moved to OperationRestrictions because the ReadByKeyRestriction on the FunctionImport should be put on the corresponding entityset. 
To restrict the FunctionImport we should use the OperationRestrictions term.

- Added `FunctionImport` and `ActionImport` to OperationRestrictions.

  Added FunctionImport and ActionImport based on the removal of FunctionImport from ReadRestrictions.



