### PR TITLE
[ODATA-1367] split properties markdown table into one for properties and one for terms

### DIFF
--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -351,10 +351,10 @@ module.exports.csdl2markdown = function (filename, csdl) {
         const tLines = applicableTermLines(type);
         if (tLines.length > 0) {
             lines.push('');
-            lines.push('Notable terms');
+            lines.push('**Notable terms:**');
             lines.push('');
-            lines.push('Term|Type');
-            lines.push(':-------|:---');
+            // lines.push('Term|Type');
+            // lines.push(':-------|:---');
             lines.push(...tLines);
         }
 
@@ -366,7 +366,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
      * @param {object} type Structured type
      * @return {Array} Array of strings containing Markdown lines
      */
-    function applicableTermLines(type, parent = false) {
+    function applicableTermLines(type) {
         const lines = [];
 
         // TODO: is it necessary to include terms from base type?
@@ -374,10 +374,9 @@ module.exports.csdl2markdown = function (filename, csdl) {
         //     lines.push(...applicableTermLines(modelElement(type.$BaseType), true));
         // }
 
-        const style = parent ? '*' : '';
         const terms = type[voc.Validation.ApplicableTerms] || [];
         terms.forEach(term => {
-            lines.push(`${style}@${term}${style}|${typeLink({ $Type: term })}`);
+            lines.push(`- ${typeLink({ $Type: term })}`);
         })
 
         return lines;

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -351,10 +351,8 @@ module.exports.csdl2markdown = function (filename, csdl) {
         const tLines = applicableTermLines(type);
         if (tLines.length > 0) {
             lines.push('');
-            lines.push('**Applicable Terms:**');
+            lines.push('**Applicable Annotation Terms:**');
             lines.push('');
-            // lines.push('Term|Type');
-            // lines.push(':-------|:---');
             lines.push(...tLines);
         }
 

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -351,7 +351,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
         const tLines = applicableTermLines(type);
         if (tLines.length > 0) {
             lines.push('');
-            lines.push('**Notable terms:**');
+            lines.push('**Applicable Terms:**');
             lines.push('');
             // lines.push('Term|Type');
             // lines.push(':-------|:---');

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -237,6 +237,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
 
         if (['ComplexType', 'EntityType'].includes(type.$Kind)) {
             lines.push(...propertyTable(type));
+            lines.push(...applicableTermsTable(type));
         } else if (type.$Kind == 'EnumType') {
             lines.push(...memberTable(type));
         }
@@ -335,13 +336,53 @@ module.exports.csdl2markdown = function (filename, csdl) {
                 + '|' + descriptionInTable(p));
         });
 
+        return lines;
+    }
+
+    
+     /**
+     * Table of applicable terms of structured type
+     * @param {object} type Structured type
+     * @return {Array} Array of strings containing Markdown lines
+     */
+    function applicableTermsTable(type) {
+        const lines = [];
+
+        const tLines = applicableTermLines(type);
+        if (tLines.length > 0) {
+            lines.push('');
+            lines.push('Notable terms');
+            lines.push('');
+            lines.push('Term|Type');
+            lines.push(':-------|:---');
+            lines.push(...tLines);
+        }
+
+        return lines;
+    }
+
+    /**
+     * Table lines of applicable terms of structured type
+     * @param {object} type Structured type
+     * @return {Array} Array of strings containing Markdown lines
+     */
+    function applicableTermLines(type, parent = false) {
+        const lines = [];
+
+        // TODO: is it necessary to include terms from base type?
+        // if (type.$BaseType) {
+        //     lines.push(...applicableTermLines(modelElement(type.$BaseType), true));
+        // }
+
         const style = parent ? '*' : '';
-        (type[voc.Validation.ApplicableTerms] || []).forEach(term => {
-            lines.push(`${style}@${term}${style}|${typeLink({ $Type: term })}|Annotation`);
+        const terms = type[voc.Validation.ApplicableTerms] || [];
+        terms.forEach(term => {
+            lines.push(`${style}@${term}${style}|${typeLink({ $Type: term })}`);
         })
 
         return lines;
     }
+
 
     /**
      * Table of enumeration type members

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "odata-vocabularies",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Convert OData vocabularies in CSDL XML or CSDL JSON to GitHub Flavored Markdown",
   "homepage": "https://github.com/oasis-tcs/odata-vocabularies/blob/master/lib/README.md",
   "bugs": "https://github.com/oasis-tcs/odata-vocabularies/issues",

--- a/vocabularies/Org.OData.Capabilities.V1.md
+++ b/vocabularies/Org.OData.Capabilities.V1.md
@@ -206,7 +206,7 @@ Property|Type|Description
 [RequestDependencyConditionsSupported](Org.OData.Capabilities.V1.xml#L401)|Boolean|Service supports the `if` member in JSON batch requests
 [SupportedFormats](Org.OData.Capabilities.V1.xml#L404)|\[MediaType\]|Media types of supported formats for $batch
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 - [LongDescription](Org.OData.Core.V1.md#LongDescription)
@@ -223,7 +223,7 @@ Property|Type|Description
 [FilterExpressionRestrictions](Org.OData.Capabilities.V1.xml#L454)|\[[FilterExpressionRestrictionType](#FilterExpressionRestrictionType)\]|These properties only allow a subset of filter expressions. A valid filter expression for a single property can be enclosed in parentheses and combined by `and` with valid expressions for other properties.
 [MaxLevels](Org.OData.Capabilities.V1.xml#L458)|Int32|The maximum number of levels (including recursion) that can be traversed in a filter expression. A value of -1 indicates there is no restriction.
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -259,7 +259,7 @@ Property|Type|Description
 [DescendingOnlyProperties](Org.OData.Capabilities.V1.xml#L526)|\[PropertyPath\]|These properties can only be used for sorting in Descending order
 [NonSortableProperties](Org.OData.Capabilities.V1.xml#L529)|\[PropertyPath\]|These structural properties cannot be used in orderby expressions
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -274,7 +274,7 @@ Property|Type|Description
 [NonExpandableStreamProperties](Org.OData.Capabilities.V1.xml#L552)|\[PropertyPath\]|These stream properties cannot be used in expand expressions
 [MaxLevels](Org.OData.Capabilities.V1.xml#L556)|Int32|The maximum number of levels that can be expanded in a expand expression. A value of -1 indicates there is no restriction.
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -286,7 +286,7 @@ Property|Type|Description
 [Searchable](Org.OData.Capabilities.V1.xml#L571)|Boolean|$search is supported
 [UnsupportedExpressions](Org.OData.Capabilities.V1.xml#L574)|[SearchExpressions](#SearchExpressions)|Expressions not supported in $search
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 

--- a/vocabularies/Org.OData.Capabilities.V1.md
+++ b/vocabularies/Org.OData.Capabilities.V1.md
@@ -206,12 +206,10 @@ Property|Type|Description
 [RequestDependencyConditionsSupported](Org.OData.Capabilities.V1.xml#L401)|Boolean|Service supports the `if` member in JSON batch requests
 [SupportedFormats](Org.OData.Capabilities.V1.xml#L404)|\[MediaType\]|Media types of supported formats for $batch
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)
-@Core.LongDescription|[LongDescription](Org.OData.Core.V1.md#LongDescription)
+- [Description](Org.OData.Core.V1.md#Description)
+- [LongDescription](Org.OData.Core.V1.md#LongDescription)
 
 ## <a name="FilterRestrictionsType"></a>[FilterRestrictionsType](Org.OData.Capabilities.V1.xml#L433)
 
@@ -225,11 +223,9 @@ Property|Type|Description
 [FilterExpressionRestrictions](Org.OData.Capabilities.V1.xml#L454)|\[[FilterExpressionRestrictionType](#FilterExpressionRestrictionType)\]|These properties only allow a subset of filter expressions. A valid filter expression for a single property can be enclosed in parentheses and combined by `and` with valid expressions for other properties.
 [MaxLevels](Org.OData.Capabilities.V1.xml#L458)|Int32|The maximum number of levels (including recursion) that can be traversed in a filter expression. A value of -1 indicates there is no restriction.
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)
+- [Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="FilterExpressionRestrictionType"></a>[FilterExpressionRestrictionType](Org.OData.Capabilities.V1.xml#L463)
 
@@ -263,11 +259,9 @@ Property|Type|Description
 [DescendingOnlyProperties](Org.OData.Capabilities.V1.xml#L526)|\[PropertyPath\]|These properties can only be used for sorting in Descending order
 [NonSortableProperties](Org.OData.Capabilities.V1.xml#L529)|\[PropertyPath\]|These structural properties cannot be used in orderby expressions
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)
+- [Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="ExpandRestrictionsType"></a>[ExpandRestrictionsType](Org.OData.Capabilities.V1.xml#L537)
 
@@ -280,11 +274,9 @@ Property|Type|Description
 [NonExpandableStreamProperties](Org.OData.Capabilities.V1.xml#L552)|\[PropertyPath\]|These stream properties cannot be used in expand expressions
 [MaxLevels](Org.OData.Capabilities.V1.xml#L556)|Int32|The maximum number of levels that can be expanded in a expand expression. A value of -1 indicates there is no restriction.
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)
+- [Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="SearchRestrictionsType"></a>[SearchRestrictionsType](Org.OData.Capabilities.V1.xml#L565)
 
@@ -294,11 +286,9 @@ Property|Type|Description
 [Searchable](Org.OData.Capabilities.V1.xml#L571)|Boolean|$search is supported
 [UnsupportedExpressions](Org.OData.Capabilities.V1.xml#L574)|[SearchExpressions](#SearchExpressions)|Expressions not supported in $search
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)
+- [Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="SearchExpressions"></a>[SearchExpressions](Org.OData.Capabilities.V1.xml#L578)
 

--- a/vocabularies/Org.OData.Capabilities.V1.md
+++ b/vocabularies/Org.OData.Capabilities.V1.md
@@ -205,8 +205,13 @@ Property|Type|Description
 [EtagReferencesSupported](Org.OData.Capabilities.V1.xml#L398)|Boolean|Service supports referencing Etags from previous requests
 [RequestDependencyConditionsSupported](Org.OData.Capabilities.V1.xml#L401)|Boolean|Service supports the `if` member in JSON batch requests
 [SupportedFormats](Org.OData.Capabilities.V1.xml#L404)|\[MediaType\]|Media types of supported formats for $batch
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)|Annotation
-@Core.LongDescription|[LongDescription](Org.OData.Core.V1.md#LongDescription)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.Description|[Description](Org.OData.Core.V1.md#Description)
+@Core.LongDescription|[LongDescription](Org.OData.Core.V1.md#LongDescription)
 
 ## <a name="FilterRestrictionsType"></a>[FilterRestrictionsType](Org.OData.Capabilities.V1.xml#L433)
 
@@ -219,7 +224,12 @@ Property|Type|Description
 [NonFilterableProperties](Org.OData.Capabilities.V1.xml#L449)|\[PropertyPath\]|These structural properties cannot be used in filter expressions
 [FilterExpressionRestrictions](Org.OData.Capabilities.V1.xml#L454)|\[[FilterExpressionRestrictionType](#FilterExpressionRestrictionType)\]|These properties only allow a subset of filter expressions. A valid filter expression for a single property can be enclosed in parentheses and combined by `and` with valid expressions for other properties.
 [MaxLevels](Org.OData.Capabilities.V1.xml#L458)|Int32|The maximum number of levels (including recursion) that can be traversed in a filter expression. A value of -1 indicates there is no restriction.
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.Description|[Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="FilterExpressionRestrictionType"></a>[FilterExpressionRestrictionType](Org.OData.Capabilities.V1.xml#L463)
 
@@ -252,7 +262,12 @@ Property|Type|Description
 [AscendingOnlyProperties](Org.OData.Capabilities.V1.xml#L523)|\[PropertyPath\]|These properties can only be used for sorting in Ascending order
 [DescendingOnlyProperties](Org.OData.Capabilities.V1.xml#L526)|\[PropertyPath\]|These properties can only be used for sorting in Descending order
 [NonSortableProperties](Org.OData.Capabilities.V1.xml#L529)|\[PropertyPath\]|These structural properties cannot be used in orderby expressions
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.Description|[Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="ExpandRestrictionsType"></a>[ExpandRestrictionsType](Org.OData.Capabilities.V1.xml#L537)
 
@@ -264,7 +279,12 @@ Property|Type|Description
 [NonExpandableProperties](Org.OData.Capabilities.V1.xml#L549)|\[NavigationPropertyPath\]|These properties cannot be used in expand expressions
 [NonExpandableStreamProperties](Org.OData.Capabilities.V1.xml#L552)|\[PropertyPath\]|These stream properties cannot be used in expand expressions
 [MaxLevels](Org.OData.Capabilities.V1.xml#L556)|Int32|The maximum number of levels that can be expanded in a expand expression. A value of -1 indicates there is no restriction.
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.Description|[Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="SearchRestrictionsType"></a>[SearchRestrictionsType](Org.OData.Capabilities.V1.xml#L565)
 
@@ -273,7 +293,12 @@ Property|Type|Description
 :-------|:---|:----------
 [Searchable](Org.OData.Capabilities.V1.xml#L571)|Boolean|$search is supported
 [UnsupportedExpressions](Org.OData.Capabilities.V1.xml#L574)|[SearchExpressions](#SearchExpressions)|Expressions not supported in $search
-@Core.Description|[Description](Org.OData.Core.V1.md#Description)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.Description|[Description](Org.OData.Core.V1.md#Description)
 
 ## <a name="SearchExpressions"></a>[SearchExpressions](Org.OData.Capabilities.V1.xml#L578)
 

--- a/vocabularies/Org.OData.Capabilities.V1.md
+++ b/vocabularies/Org.OData.Capabilities.V1.md
@@ -206,7 +206,7 @@ Property|Type|Description
 [RequestDependencyConditionsSupported](Org.OData.Capabilities.V1.xml#L401)|Boolean|Service supports the `if` member in JSON batch requests
 [SupportedFormats](Org.OData.Capabilities.V1.xml#L404)|\[MediaType\]|Media types of supported formats for $batch
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 - [LongDescription](Org.OData.Core.V1.md#LongDescription)
@@ -223,7 +223,7 @@ Property|Type|Description
 [FilterExpressionRestrictions](Org.OData.Capabilities.V1.xml#L454)|\[[FilterExpressionRestrictionType](#FilterExpressionRestrictionType)\]|These properties only allow a subset of filter expressions. A valid filter expression for a single property can be enclosed in parentheses and combined by `and` with valid expressions for other properties.
 [MaxLevels](Org.OData.Capabilities.V1.xml#L458)|Int32|The maximum number of levels (including recursion) that can be traversed in a filter expression. A value of -1 indicates there is no restriction.
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -259,7 +259,7 @@ Property|Type|Description
 [DescendingOnlyProperties](Org.OData.Capabilities.V1.xml#L526)|\[PropertyPath\]|These properties can only be used for sorting in Descending order
 [NonSortableProperties](Org.OData.Capabilities.V1.xml#L529)|\[PropertyPath\]|These structural properties cannot be used in orderby expressions
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -274,7 +274,7 @@ Property|Type|Description
 [NonExpandableStreamProperties](Org.OData.Capabilities.V1.xml#L552)|\[PropertyPath\]|These stream properties cannot be used in expand expressions
 [MaxLevels](Org.OData.Capabilities.V1.xml#L556)|Int32|The maximum number of levels that can be expanded in a expand expression. A value of -1 indicates there is no restriction.
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 
@@ -286,7 +286,7 @@ Property|Type|Description
 [Searchable](Org.OData.Capabilities.V1.xml#L571)|Boolean|$search is supported
 [UnsupportedExpressions](Org.OData.Capabilities.V1.xml#L574)|[SearchExpressions](#SearchExpressions)|Expressions not supported in $search
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [Description](Org.OData.Core.V1.md#Description)
 

--- a/vocabularies/Org.OData.Validation.V1.md
+++ b/vocabularies/Org.OData.Validation.V1.md
@@ -30,7 +30,7 @@ Property|Type|Description
 :-------|:---|:----------
 [Value](Org.OData.Validation.V1.xml#L103)|PrimitiveType|An allowed value for the property, parameter, or type definition
 
-**Applicable Terms:**
+**Applicable Annotation Terms:**
 
 - [SymbolicName](Org.OData.Core.V1.md#SymbolicName)
 

--- a/vocabularies/Org.OData.Validation.V1.md
+++ b/vocabularies/Org.OData.Validation.V1.md
@@ -29,7 +29,12 @@ Term|Type|Description
 Property|Type|Description
 :-------|:---|:----------
 [Value](Org.OData.Validation.V1.xml#L103)|PrimitiveType|An allowed value for the property, parameter, or type definition
-@Core.SymbolicName|[SymbolicName](Org.OData.Core.V1.md#SymbolicName)|Annotation
+
+Notable terms
+
+Term|Type
+:-------|:---
+@Core.SymbolicName|[SymbolicName](Org.OData.Core.V1.md#SymbolicName)
 
 ## <a name="ConstraintType"></a>[ConstraintType](Org.OData.Validation.V1.xml#L115)
 

--- a/vocabularies/Org.OData.Validation.V1.md
+++ b/vocabularies/Org.OData.Validation.V1.md
@@ -30,7 +30,7 @@ Property|Type|Description
 :-------|:---|:----------
 [Value](Org.OData.Validation.V1.xml#L103)|PrimitiveType|An allowed value for the property, parameter, or type definition
 
-**Notable terms:**
+**Applicable Terms:**
 
 - [SymbolicName](Org.OData.Core.V1.md#SymbolicName)
 

--- a/vocabularies/Org.OData.Validation.V1.md
+++ b/vocabularies/Org.OData.Validation.V1.md
@@ -30,11 +30,9 @@ Property|Type|Description
 :-------|:---|:----------
 [Value](Org.OData.Validation.V1.xml#L103)|PrimitiveType|An allowed value for the property, parameter, or type definition
 
-Notable terms
+**Notable terms:**
 
-Term|Type
-:-------|:---
-@Core.SymbolicName|[SymbolicName](Org.OData.Core.V1.md#SymbolicName)
+- [SymbolicName](Org.OData.Core.V1.md#SymbolicName)
 
 ## <a name="ConstraintType"></a>[ConstraintType](Org.OData.Validation.V1.xml#L115)
 


### PR DESCRIPTION
- split the single call to propertyTable in function typeSection into to
- moved functionality from propertyTable and propertyLines pertaining applicable terms into new functions applicableTermsTable and applicableTermLines respectively.
- changed layout of applicableTermsTable to two columns
- re-generated capabilities and Validation markdown files