### PR TITLE
ODATA-1382

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
+		"hbenl.vscode-mocha-test-adapter",
 		"redhat.vscode-xml"
 	]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,10 @@
 {
 	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
 	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
 	// List of extensions which should be recommended for users of this workspace.
 	"recommendations": [
 		"hbenl.vscode-mocha-test-adapter",
+		"hbenl.vscode-test-explorer",
 		"redhat.vscode-xml"
 	]
 }

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -122,7 +122,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
 
         for (const [filename, referencedCsdl] of Object.entries(referenced)) {
             Object.keys(referencedCsdl).filter(name => isIdentifier(name)).forEach(namespace => {
-                if (index.schema.$$namespace !== namespace && index.namespace[namespace]) {
+                if (index.schema.$$namespace !== namespace) {
                     index.schemas[namespace] = referencedCsdl[namespace];
                     index.schemas[namespace].$$filename = filename;
                 }

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -13,7 +13,7 @@
  * @param {object} csdl CSDL document
  * @return {Array} Array of strings containing Markdown lines
  */
-module.exports.csdl2markdown = function (filename, csdl) {
+module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
     const lines = [];
     const index = {
         alias: {},
@@ -26,7 +26,8 @@ module.exports.csdl2markdown = function (filename, csdl) {
         types: [],
         derivedTypes: {}
     };
-    preProcess(csdl, index);
+    preProcess(index, csdl, referenced);
+    index.schema.$$filename = filename
     const voc = vocabularies(index.alias);
     const sourceLine = '@parser.line';
 
@@ -55,10 +56,11 @@ module.exports.csdl2markdown = function (filename, csdl) {
 
     /**
      * Collect model info for easier lookup
-     * @param {object} csdl CSDL document
      * @param {object} index Map of model elements
+     * @param {object} csdl main CSDL document
+     * @param {object} referenced more CSDL documents
      */
-    function preProcess(csdl, index) {
+    function preProcess(index, csdl, referenced) {
         Object.keys(csdl.$Reference || {}).forEach(url => {
             const reference = csdl.$Reference[url];
             (reference.$Include || []).forEach(include => {
@@ -72,14 +74,15 @@ module.exports.csdl2markdown = function (filename, csdl) {
             });
         });
 
+        // implicit assumption: exactly one schema in a vocabulary
         Object.keys(csdl).filter(name => isIdentifier(name)).forEach(name => {
             index.schema = csdl[name];
             index.schema.$$namespace = name;
-            index.schema.qualifier = index.schema.$Alias || name;
+            index.qualifier = index.schema.$Alias || name;
 
-            index.alias[name] = index.schema.qualifier;
-            index.alias[index.schema.qualifier] = index.schema.qualifier;
-            index.namespace[index.schema.qualifier] = name;
+            index.alias[name] = index.qualifier;
+            index.alias[index.qualifier] = index.qualifier;
+            index.namespace[index.qualifier] = name;
             index.namespace[name] = name;
 
             Object.keys(index.schema).filter(name => isIdentifier(name)).forEach(name => {
@@ -101,6 +104,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
                             index.terms.push(element);
                             break;
                         case 'ComplexType':
+                        case 'EntityType':
                         case 'EnumType':
                         case 'TypeDefinition':
                             index.types.push(element);
@@ -109,11 +113,21 @@ module.exports.csdl2markdown = function (filename, csdl) {
 
                     if (element.$BaseType) {
                         if (!index.derivedTypes[element.$BaseType]) index.derivedTypes[element.$BaseType] = [];
-                        index.derivedTypes[element.$BaseType].push(index.schema.qualifier + '.' + name);
+                        index.derivedTypes[element.$BaseType].push(index.qualifier + '.' + name);
                     }
                 }
             });
         });
+
+        for (const r of Object.values(referenced)) {
+            Object.keys(r).filter(name => isIdentifier(name)).forEach(name => {
+                if (name !== index.schema.$$namespace) {
+                    csdl[name] = r[name];
+                    //TODO: not so :-)
+                    csdl[name].$$filename = name + '.xml';
+                }
+            })
+        }
     }
 
     /**
@@ -228,7 +242,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
             lines.push(...longDescription.split('\n'));
         }
 
-        const derivedTypes = index.derivedTypes[index.schema.qualifier + '.' + type.$$name];
+        const derivedTypes = index.derivedTypes[index.qualifier + '.' + type.$$name];
         if (derivedTypes) {
             lines.push('');
             lines.push('**Derived Types:**');
@@ -319,6 +333,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
     /**
      * Table lines of properties of structured type
      * @param {object} type Structured type
+     * @param {boolean} parent Current type is base type of "original" type
      * @return {Array} Array of strings containing Markdown lines
      */
     function propertyLines(type, parent = false) {
@@ -333,6 +348,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
         Object.keys(type).filter(name => isIdentifier(name)).forEach(name => {
             const p = type[name];
             p.$$name = name;
+            p.$$filename = type.$$filename
             lines.push(sourceLink(p, parent) + experimentalOrDeprecated(p)
                 + '|' + typeLink(p)
                 + '|' + descriptionInTable(p));
@@ -498,7 +514,7 @@ module.exports.csdl2markdown = function (filename, csdl) {
             + (modelElement.$Abstract || parent ? '*' : '')
             + modelElement.$$name
             + (modelElement.$Abstract || parent ? '*' : '')
-            + (line ? '](' + filename + '#L' + line + ')' : '');
+            + (line ? '](' + (modelElement.$$filename || filename) + '#L' + line + ')' : '');
     }
 
     /**
@@ -591,7 +607,9 @@ module.exports.csdl2markdown = function (filename, csdl) {
         const q = nameParts(qname);
         const schema = csdl[q.qualifier] || csdl[index.namespace[q.qualifier]];
         const element = schema ? schema[q.name] : null;
-        if (!element) console.warn(`- Cannot find '${qname}'`)
+        if (!element) console.warn(`- Cannot find '${qname}'`);
+        if (element) element.$$filename = schema.$$filename;
+        // console.dir(schema.$$filename)
         return element;
     }
 

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -120,12 +120,11 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
             });
         });
 
-        for (const r of Object.values(referenced)) {
-            Object.keys(r).filter(name => isIdentifier(name)).forEach(namespace => {
+        for (const [filename, referencedCsdl] of Object.entries(referenced)) {
+            Object.keys(referencedCsdl).filter(name => isIdentifier(name)).forEach(namespace => {
                 if (index.schema.$$namespace !== namespace && index.namespace[namespace]) {
-                    index.schemas[namespace] = r[namespace];
-                    //TODO: not so :-)
-                    index.schemas[namespace].$$filename = namespace + '.xml';
+                    index.schemas[namespace] = referencedCsdl[namespace];
+                    index.schemas[namespace].$$filename = filename;
                 }
             })
         }

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -324,6 +324,8 @@ module.exports.csdl2markdown = function (filename, csdl) {
     function propertyLines(type, parent = false) {
         const lines = [];
 
+        if (!type) return lines;
+
         if (type.$BaseType) {
             lines.push(...propertyLines(modelElement(type.$BaseType), true));
         }
@@ -365,6 +367,8 @@ module.exports.csdl2markdown = function (filename, csdl) {
      */
     function applicableTermLines(type) {
         const lines = [];
+
+        if (!type) return lines;
 
         if (type.$BaseType) {
             lines.push(...applicableTermLines(modelElement(type.$BaseType), true));
@@ -586,7 +590,9 @@ module.exports.csdl2markdown = function (filename, csdl) {
     function modelElement(qname) {
         const q = nameParts(qname);
         const schema = csdl[q.qualifier] || csdl[index.namespace[q.qualifier]];
-        return schema ? schema[q.name] : null;
+        const element = schema ? schema[q.name] : null;
+        if (!element) console.warn(`- Cannot find '${qname}'`)
+        return element;
     }
 
 }

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -20,6 +20,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
         namespace: { 'Edm': 'Edm' },
         namespaceUrl: {},
         schema: {},
+        schemas: {},
         terms: [],
         actions: [],
         functions: [],
@@ -27,7 +28,6 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
         derivedTypes: {}
     };
     preProcess(index, csdl, referenced);
-    index.schema.$$filename = filename
     const voc = vocabularies(index.alias);
     const sourceLine = '@parser.line';
 
@@ -76,6 +76,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
 
         // implicit assumption: exactly one schema in a vocabulary
         Object.keys(csdl).filter(name => isIdentifier(name)).forEach(name => {
+            index.schemas[name] = csdl[name];
             index.schema = csdl[name];
             index.schema.$$namespace = name;
             index.qualifier = index.schema.$Alias || name;
@@ -120,11 +121,11 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
         });
 
         for (const r of Object.values(referenced)) {
-            Object.keys(r).filter(name => isIdentifier(name)).forEach(name => {
-                if (name !== index.schema.$$namespace) {
-                    csdl[name] = r[name];
+            Object.keys(r).filter(name => isIdentifier(name)).forEach(namespace => {
+                if (index.schema.$$namespace !== namespace && index.namespace[namespace]) {
+                    index.schemas[namespace] = r[namespace];
                     //TODO: not so :-)
-                    csdl[name].$$filename = name + '.xml';
+                    index.schemas[namespace].$$filename = namespace + '.xml';
                 }
             })
         }
@@ -605,11 +606,10 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
      */
     function modelElement(qname) {
         const q = nameParts(qname);
-        const schema = csdl[q.qualifier] || csdl[index.namespace[q.qualifier]];
+        const schema = index.schemas[q.qualifier] || index.schemas[index.namespace[q.qualifier]];
         const element = schema ? schema[q.name] : null;
         if (!element) console.warn(`- Cannot find '${qname}'`);
-        if (element) element.$$filename = schema.$$filename;
-        // console.dir(schema.$$filename)
+        if (element && schema.$$filename) element.$$filename = schema.$$filename;
         return element;
     }
 

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -8,16 +8,17 @@ const fs = require('fs');
 const vocabFolder = './vocabularies/';
 const exampleFolder = './examples/';
 
-fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(xmlfile => {
-    const vocab = xmlfile.substring(0, xmlfile.lastIndexOf('.'));
-    console.log(xmlfile);
+const vocabs = {};
 
-    const xml = fs.readFileSync(vocabFolder + xmlfile, 'utf8');
+fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(filename => {
+    const vocab = filename.substring(0, filename.lastIndexOf('.'));
+    console.log(vocab + '.json');
 
-    const jsonWithLineNumbers = csdl.xml2json(xml, true);
-    const markdown = lib.csdl2markdown(xmlfile, jsonWithLineNumbers);
-    fs.writeFileSync(vocabFolder + vocab + '.md', markdown.join('\n'));
+    const xml = fs.readFileSync(vocabFolder + filename, 'utf8');
 
+    vocabs[vocab] = csdl.xml2json(xml, true);
+
+    //TODO: can we get rid of the "with line-numbers" operation mode?
     const json = csdl.xml2json(xml, false);
     // swap URLs of latest-version and alternate links
     const links = json[vocab]['@Core.Links'];
@@ -32,9 +33,17 @@ fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(xmlfile =>
 
 console.log();
 
+for (const [vocab, csdl] of Object.entries(vocabs)) {
+    console.log(vocab + '.md');
+    const markdown = lib.csdl2markdown(vocab + '.xml', csdl, vocabs);
+    fs.writeFileSync(vocabFolder + vocab + '.md', markdown.join('\n'));
+}
+
+console.log();
+
 fs.readdirSync(exampleFolder).filter(fn => fn.endsWith('.xml')).forEach(xmlfile => {
     const example = xmlfile.substring(0, xmlfile.lastIndexOf('.'));
-    console.log(xmlfile);
+    console.log(example + '.json');
 
     const xml = fs.readFileSync(exampleFolder + xmlfile, 'utf8');
     const json = csdl.xml2json(xml, false);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -15,11 +15,10 @@ fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(filename =
     console.log(vocab + '.json');
 
     const xml = fs.readFileSync(vocabFolder + filename, 'utf8');
+    const json = csdl.xml2json(xml, true);
 
-    vocabs[vocab] = csdl.xml2json(xml, true);
+    vocabs[vocab] = json
 
-    //TODO: can we get rid of the "with line-numbers" operation mode?
-    const json = csdl.xml2json(xml, false);
     // swap URLs of latest-version and alternate links
     const links = json[vocab]['@Core.Links'];
     const latestVersion = links.findIndex(l => l.rel == 'latest-version');
@@ -28,7 +27,7 @@ fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(filename =
         links[latestVersion].rel = 'alternate';
         links[alternate].rel = 'latest-version';
     }
-    fs.writeFileSync(vocabFolder + vocab + '.json', JSON.stringify(json, null, 4));
+    fs.writeFileSync(vocabFolder + vocab + '.json', JSON.stringify(json, omitLineNumbers, 4));
 });
 
 console.log();
@@ -49,3 +48,10 @@ fs.readdirSync(exampleFolder).filter(fn => fn.endsWith('.xml')).forEach(xmlfile 
     const json = csdl.xml2json(xml, false);
     fs.writeFileSync(exampleFolder + example + '.json', JSON.stringify(json, null, 4));
 });
+
+function omitLineNumbers(key, value) {
+    if (key.endsWith('@parser.line')) {
+        return undefined;
+    }
+    return value;
+}

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -17,7 +17,7 @@ fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(filename =
     const xml = fs.readFileSync(vocabFolder + filename, 'utf8');
     const json = csdl.xml2json(xml, true);
 
-    vocabs[vocab] = json
+    vocabs[filename] = json
 
     // swap URLs of latest-version and alternate links
     const links = json[vocab]['@Core.Links'];
@@ -32,9 +32,11 @@ fs.readdirSync(vocabFolder).filter(fn => fn.endsWith('.xml')).forEach(filename =
 
 console.log();
 
-for (const [vocab, csdl] of Object.entries(vocabs)) {
+for (const [filename, csdl] of Object.entries(vocabs)) {
+    const vocab = filename.substring(0, filename.lastIndexOf('.'));
     console.log(vocab + '.md');
-    const markdown = lib.csdl2markdown(vocab + '.xml', csdl, vocabs);
+
+    const markdown = lib.csdl2markdown(filename, csdl, vocabs);
     fs.writeFileSync(vocabFolder + vocab + '.md', markdown.join('\n'));
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "build": "node lib/transform.js",
-    "test": "mocha"
+    "test": "mocha",
+    "watch": "mocha --watch"
   },
   "author": "",
   "license": "SEE LICENSE IN LICENSE.md"

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -16,9 +16,14 @@ vocabularies.forEach(v => {
 
 describe('OASIS Vocabularies', function () {
 
+    it('Validation without potentially referenced vocabularies', function () {
+        const markdown = lib.csdl2markdown('Org.OData.Validation.V1.xml', input.Validation);
+        check(markdown, expected.Validation);
+    })
+
     vocabularies.forEach(v => {
         it(v, function () {
-            const markdown = lib.csdl2markdown('Org.OData.' + v + '.V1.xml', input[v]);
+            const markdown = lib.csdl2markdown('Org.OData.' + v + '.V1.xml', input[v], input);
             check(markdown, expected[v]);
         })
     })

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -10,20 +10,23 @@ const expected = {};
 const vocabularies = ['Aggregation', 'Authorization', 'Capabilities', 'Core', 'Measures', 'Repeatability', 'Temporal', 'Validation'];
 
 vocabularies.forEach(v => {
-    input[v] = csdl.xml2json(fs.readFileSync('vocabularies/Org.OData.' + v + '.V1.xml'), true);
-    expected[v] = fs.readFileSync('vocabularies/Org.OData.' + v + '.V1.md', 'utf8');
+    const vocab = `Org.OData.${v}.V1`;
+    input[`${vocab}.xml`] = csdl.xml2json(fs.readFileSync(`vocabularies/${vocab}.xml`), true);
+    expected[v] = fs.readFileSync(`vocabularies/${vocab}.md`, 'utf8');
 })
 
 describe('OASIS Vocabularies', function () {
 
     it('Validation without potentially referenced vocabularies', function () {
-        const markdown = lib.csdl2markdown('Org.OData.Validation.V1.xml', input.Validation);
+        const filename = 'Org.OData.Validation.V1.xml'
+        const markdown = lib.csdl2markdown(filename, input[filename]);
         check(markdown, expected.Validation);
     })
 
     vocabularies.forEach(v => {
         it(v, function () {
-            const markdown = lib.csdl2markdown('Org.OData.' + v + '.V1.xml', input[v], input);
+            const filename = `Org.OData.${v}.V1.xml`;
+            const markdown = lib.csdl2markdown(filename, input[filename], input);
             check(markdown, expected[v]);
         })
     })

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -25,26 +25,6 @@ describe('OASIS Vocabularies', function () {
 
 })
 
-//TODO: remove from here
-// const sapVocabs = ['Analytics', 'CodeList', 'Common', 'Communication', 'Hierarchy', 'PersonalData', 'Session', 'UI'];
-
-// sapVocabs.forEach(v => {
-//     input[v] = csdl.xml2json(fs.readFileSync('../vocabularies/' + v + '.xml'), true);
-//     expected[v] = fs.readFileSync('../vocabularies/' + v + '.md', 'utf8');
-// })
-
-// describe('SAP Vocabularies', function () {
-
-//     sapVocabs.forEach(v => {
-//         it(v, function () {
-//             const markdown = lib.csdl2markdown(v + '.xml', input[v]);
-//             check(markdown, expected[v]);
-//         })
-//     })
-
-// })
-//TODO: remove up to here
-
 function check(actual, expected) {
     assert.deepStrictEqual(actual, expected.split(/\r\n|\r|\n/g), 'Markdown');
 }

--- a/vocabularies/Org.OData.Aggregation.V1.json
+++ b/vocabularies/Org.OData.Aggregation.V1.json
@@ -302,7 +302,6 @@
             "$Kind": "ComplexType",
             "$BaseType": "Capabilities.NavigationPropertyRestriction",
             "@Core.Description": "Aggregation capabilities on a navigation path",
-            "@Core.LongDescription": "This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.",
             "ApplySupported": {
                 "$Type": "Aggregation.ApplySupportedType",
                 "$Nullable": true,

--- a/vocabularies/Org.OData.Aggregation.V1.json
+++ b/vocabularies/Org.OData.Aggregation.V1.json
@@ -302,6 +302,7 @@
             "$Kind": "ComplexType",
             "$BaseType": "Capabilities.NavigationPropertyRestriction",
             "@Core.Description": "Aggregation restrictions on a navigation path",
+            "@Core.LongDescription": "This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.",
             "ApplySupported": {
                 "$Type": "Aggregation.ApplySupportedType",
                 "$Nullable": true,

--- a/vocabularies/Org.OData.Aggregation.V1.json
+++ b/vocabularies/Org.OData.Aggregation.V1.json
@@ -40,7 +40,7 @@
             "$Type": "Aggregation.ApplySupportedType",
             "$Nullable": true,
             "$AppliesTo": [
-                "EntityType",
+                "EntitySet",
                 "ComplexType",
                 "EntityContainer"
             ],
@@ -103,7 +103,7 @@
             "$Kind": "Term",
             "$Nullable": true,
             "$AppliesTo": [
-                "EntityType",
+                "EntitySet",
                 "ComplexType",
                 "EntityContainer"
             ],
@@ -298,10 +298,10 @@
                 "@Core.Description": "Properties required to apply this action or function"
             }
         },
-        "NavigationPropertyRestriction": {
+        "NavigationPropertyAggregationCapabilities": {
             "$Kind": "ComplexType",
             "$BaseType": "Capabilities.NavigationPropertyRestriction",
-            "@Core.Description": "Aggregation restrictions on a navigation path",
+            "@Core.Description": "Aggregation capabilities on a navigation path",
             "@Core.LongDescription": "This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.",
             "ApplySupported": {
                 "$Type": "Aggregation.ApplySupportedType",

--- a/vocabularies/Org.OData.Aggregation.V1.json
+++ b/vocabularies/Org.OData.Aggregation.V1.json
@@ -8,6 +8,14 @@
                     "$Alias": "Core"
                 }
             ]
+        },
+        "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.json": {
+            "$Include": [
+                {
+                    "$Namespace": "Org.OData.Capabilities.V1",
+                    "$Alias": "Capabilities"
+                }
+            ]
         }
     },
     "Org.OData.Aggregation.V1": {
@@ -288,6 +296,28 @@
                 "$Collection": true,
                 "$Type": "Edm.PropertyPath",
                 "@Core.Description": "Properties required to apply this action or function"
+            }
+        },
+        "NavigationPropertyRestriction": {
+            "$Kind": "ComplexType",
+            "$BaseType": "Capabilities.NavigationPropertyRestriction",
+            "@Core.Description": "Aggregation restrictions on a navigation path",
+            "ApplySupported": {
+                "$Type": "Aggregation.ApplySupportedType",
+                "$Nullable": true,
+                "@Core.Description": "Support for $apply"
+            },
+            "CustomAggregates": {
+                "$Collection": true,
+                "@Core.Description": "Supported custom aggregates identified by their qualifier"
+            },
+            "GroupableProperties": {
+                "$Collection": true,
+                "@Core.Description": "Properties supported by the groupby transformation"
+            },
+            "AggregatableProperties": {
+                "$Collection": true,
+                "@Core.Description": "Properties supported by the aggregate transformation"
             }
         }
     }

--- a/vocabularies/Org.OData.Aggregation.V1.md
+++ b/vocabularies/Org.OData.Aggregation.V1.md
@@ -71,6 +71,23 @@ This type derives from type NavigationPropertyRestriction in the Capabilities vo
 
 Property|Type|Description
 :-------|:---|:----------
+[*NavigationProperty*](Org.OData.Capabilities.V1.xml#L250)|NavigationPropertyPath|Navigation properties can be navigated
+[*Navigability*](Org.OData.Capabilities.V1.xml#L253)|[NavigationType](Org.OData.Capabilities.V1.md#NavigationType)|Supported navigability of this navigation property
+[*FilterFunctions*](Org.OData.Capabilities.V1.xml#L256)|\[String\]|List of functions and operators supported in filter expressions<p>If not specified, null, or empty, all functions and operators may be attempted.</p>
+[*FilterRestrictions*](Org.OData.Capabilities.V1.xml#L261)|[FilterRestrictionsType](Org.OData.Capabilities.V1.md#FilterRestrictionsType)|Restrictions on filter expressions
+[*SearchRestrictions*](Org.OData.Capabilities.V1.xml#L264)|[SearchRestrictionsType](Org.OData.Capabilities.V1.md#SearchRestrictionsType)|Restrictions on search expressions
+[*SortRestrictions*](Org.OData.Capabilities.V1.xml#L267)|[SortRestrictionsType](Org.OData.Capabilities.V1.md#SortRestrictionsType)|Restrictions on orderby expressions
+[*TopSupported*](Org.OData.Capabilities.V1.xml#L270)|Boolean|Supports $top
+[*SkipSupported*](Org.OData.Capabilities.V1.xml#L273)|Boolean|Supports $skip
+[*SelectSupport*](Org.OData.Capabilities.V1.xml#L276)|[SelectSupportType](Org.OData.Capabilities.V1.md#SelectSupportType)|Support for $select
+[*IndexableByKey*](Org.OData.Capabilities.V1.xml#L279)|Boolean|Supports key values according to OData URL conventions
+[*InsertRestrictions*](Org.OData.Capabilities.V1.xml#L282)|[InsertRestrictionsType](Org.OData.Capabilities.V1.md#InsertRestrictionsType)|Restrictions on insert operations
+[*DeepInsertSupport*](Org.OData.Capabilities.V1.xml#L285)|[DeepInsertSupportType](Org.OData.Capabilities.V1.md#DeepInsertSupportType)|Deep Insert Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)
+[*UpdateRestrictions*](Org.OData.Capabilities.V1.xml#L289)|[UpdateRestrictionsType](Org.OData.Capabilities.V1.md#UpdateRestrictionsType)|Restrictions on update operations
+[*DeepUpdateSupport*](Org.OData.Capabilities.V1.xml#L292)|[DeepUpdateSupportType](Org.OData.Capabilities.V1.md#DeepUpdateSupportType)|Deep Update Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)
+[*DeleteRestrictions*](Org.OData.Capabilities.V1.xml#L296)|[DeleteRestrictionsType](Org.OData.Capabilities.V1.md#DeleteRestrictionsType)|Restrictions on delete operations
+[*OptimisticConcurrencyControl*](Org.OData.Capabilities.V1.xml#L299)|Boolean|Data modification (including insert) along this navigation property requires the use of ETags
+[*ReadRestrictions*](Org.OData.Capabilities.V1.xml#L303)|[ReadRestrictionsType](Org.OData.Capabilities.V1.md#ReadRestrictionsType)|Restrictions for retrieving entities
 [ApplySupported](Org.OData.Aggregation.V1.xml#L213)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
 [CustomAggregates](Org.OData.Aggregation.V1.xml#L216)|\[String\]|Supported custom aggregates identified by their qualifier
 [GroupableProperties](Org.OData.Aggregation.V1.xml#L219)|\[String\]|Properties supported by the groupby transformation

--- a/vocabularies/Org.OData.Aggregation.V1.md
+++ b/vocabularies/Org.OData.Aggregation.V1.md
@@ -8,58 +8,68 @@ Terms to describe which data in a given entity model can be aggregated, and how.
 
 Term|Type|Description
 :---|:---|:----------
-[ApplySupported](Org.OData.Aggregation.V1.xml#L70)|[ApplySupportedType](#ApplySupportedType)|<a name="ApplySupported"></a>This structured type or entity container supports the $apply system query option
-[Groupable](Org.OData.Aggregation.V1.xml#L105)|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Groupable"></a>This property can be used in the groupby transformation
-[Aggregatable](Org.OData.Aggregation.V1.xml#L109)|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Aggregatable"></a>This property can be used in the aggregate transformation
-[CustomAggregate](Org.OData.Aggregation.V1.xml#L113)|String|<a name="CustomAggregate"></a>Dynamic property that can be used in the aggregate transformation<p>This term MUST be applied with a Qualifier, the Qualifier value is the name of the dynamic property. The value of the annotation MUST be the qualified name of a primitive type. The aggregated values will be of that type.</p>
-[ContextDefiningProperties](Org.OData.Aggregation.V1.xml#L119)|\[PropertyPath\]|<a name="ContextDefiningProperties"></a>The annotated property or custom aggregate is only well-defined in the context of these properties<p>The context-defining properties need either be part of the result entities, or be restricted to a single value by a pre-filter operation. Examples are postal codes within a country, or monetary amounts whose context is the unit of currency.</p>
-[LeveledHierarchy](Org.OData.Aggregation.V1.xml#L127)|\[PropertyPath\]|<a name="LeveledHierarchy"></a>Defines a leveled hierarchy by defining an ordered list of properties in the hierarchy
-[RecursiveHierarchy](Org.OData.Aggregation.V1.xml#L132)|[RecursiveHierarchyType](#RecursiveHierarchyType)|<a name="RecursiveHierarchy"></a>Defines a recursive hierarchy.
-[AvailableOnAggregates](Org.OData.Aggregation.V1.xml#L197)|[AvailableOnAggregatesType](#AvailableOnAggregatesType)|<a name="AvailableOnAggregates"></a>This action or function is available on aggregated entities if the RequiredProperties are still defined
+[ApplySupported](Org.OData.Aggregation.V1.xml#L73)|[ApplySupportedType](#ApplySupportedType)|<a name="ApplySupported"></a>This structured type or entity container supports the $apply system query option
+[Groupable](Org.OData.Aggregation.V1.xml#L108)|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Groupable"></a>This property can be used in the groupby transformation
+[Aggregatable](Org.OData.Aggregation.V1.xml#L112)|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Aggregatable"></a>This property can be used in the aggregate transformation
+[CustomAggregate](Org.OData.Aggregation.V1.xml#L116)|String|<a name="CustomAggregate"></a>Dynamic property that can be used in the aggregate transformation<p>This term MUST be applied with a Qualifier, the Qualifier value is the name of the dynamic property. The value of the annotation MUST be the qualified name of a primitive type. The aggregated values will be of that type.</p>
+[ContextDefiningProperties](Org.OData.Aggregation.V1.xml#L122)|\[PropertyPath\]|<a name="ContextDefiningProperties"></a>The annotated property or custom aggregate is only well-defined in the context of these properties<p>The context-defining properties need either be part of the result entities, or be restricted to a single value by a pre-filter operation. Examples are postal codes within a country, or monetary amounts whose context is the unit of currency.</p>
+[LeveledHierarchy](Org.OData.Aggregation.V1.xml#L130)|\[PropertyPath\]|<a name="LeveledHierarchy"></a>Defines a leveled hierarchy by defining an ordered list of properties in the hierarchy
+[RecursiveHierarchy](Org.OData.Aggregation.V1.xml#L135)|[RecursiveHierarchyType](#RecursiveHierarchyType)|<a name="RecursiveHierarchy"></a>Defines a recursive hierarchy.
+[AvailableOnAggregates](Org.OData.Aggregation.V1.xml#L200)|[AvailableOnAggregatesType](#AvailableOnAggregatesType)|<a name="AvailableOnAggregates"></a>This action or function is available on aggregated entities if the RequiredProperties are still defined
 
 
 ## Functions
 
 Function|Signature|Description
 :-------|:--------|:----------
-[isroot](Org.OData.Aggregation.V1.xml#L152)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String &rarr;&nbsp;Boolean|<a name="isroot"></a>Returns true, if and only if the value of the node property of the specified hierarchy is the root of the hierarchy
-[isdescendant](Org.OData.Aggregation.V1.xml#L160)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType, MaxDistance:&nbsp;Int16 &rarr;&nbsp;Boolean|<a name="isdescendant"></a>Returns true, if and only if the value of the node property of the specified hierarchy is a descendant of the given parent node with a distance of less than or equal to the optionally specified maximum distance
-[isancestor](Org.OData.Aggregation.V1.xml#L170)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType, MaxDistance:&nbsp;Int16 &rarr;&nbsp;Boolean|<a name="isancestor"></a>Returns true, if and only if the value of the node property of the specified hierarchy is an ancestor of the given child node with a distance of less than or equal to the optionally specified maximum distance
-[issibling](Org.OData.Aggregation.V1.xml#L180)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType &rarr;&nbsp;Boolean|<a name="issibling"></a>Returns true, if and only if the value of the node property of the specified hierarchy has the same parent node as the specified node
-[isleaf](Org.OData.Aggregation.V1.xml#L189)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String &rarr;&nbsp;Boolean|<a name="isleaf"></a>Returns true, if and only if the value of the node property of the specified hierarchy has no descendants
+[isroot](Org.OData.Aggregation.V1.xml#L155)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String &rarr;&nbsp;Boolean|<a name="isroot"></a>Returns true, if and only if the value of the node property of the specified hierarchy is the root of the hierarchy
+[isdescendant](Org.OData.Aggregation.V1.xml#L163)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType, MaxDistance:&nbsp;Int16 &rarr;&nbsp;Boolean|<a name="isdescendant"></a>Returns true, if and only if the value of the node property of the specified hierarchy is a descendant of the given parent node with a distance of less than or equal to the optionally specified maximum distance
+[isancestor](Org.OData.Aggregation.V1.xml#L173)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType, MaxDistance:&nbsp;Int16 &rarr;&nbsp;Boolean|<a name="isancestor"></a>Returns true, if and only if the value of the node property of the specified hierarchy is an ancestor of the given child node with a distance of less than or equal to the optionally specified maximum distance
+[issibling](Org.OData.Aggregation.V1.xml#L183)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String, Node:&nbsp;PrimitiveType &rarr;&nbsp;Boolean|<a name="issibling"></a>Returns true, if and only if the value of the node property of the specified hierarchy has the same parent node as the specified node
+[isleaf](Org.OData.Aggregation.V1.xml#L192)|Entity:&nbsp;EntityType, Hierarchy:&nbsp;String &rarr;&nbsp;Boolean|<a name="isleaf"></a>Returns true, if and only if the value of the node property of the specified hierarchy has no descendants
 
-## <a name="ApplySupportedType"></a>[ApplySupportedType](Org.OData.Aggregation.V1.xml#L75)
+## <a name="ApplySupportedType"></a>[ApplySupportedType](Org.OData.Aggregation.V1.xml#L78)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Transformations](Org.OData.Aggregation.V1.xml#L76)|\[String\]|Transformations that can be used in $apply
-[CustomAggregationMethods](Org.OData.Aggregation.V1.xml#L79)|\[String\]|Qualified names of custom aggregation methods that can be used in aggregate(...with...)
-[Rollup](Org.OData.Aggregation.V1.xml#L83)|[RollupType](#RollupType)|The service supports rollup hierarchies in a groupby transformation
-[PropertyRestrictions](Org.OData.Aggregation.V1.xml#L86)|Boolean|Only properties tagged as Groupable can be used in the groupby transformation, and only those tagged as Aggregatable can be used in the aggregate transformation
+[Transformations](Org.OData.Aggregation.V1.xml#L79)|\[String\]|Transformations that can be used in $apply
+[CustomAggregationMethods](Org.OData.Aggregation.V1.xml#L82)|\[String\]|Qualified names of custom aggregation methods that can be used in aggregate(...with...)
+[Rollup](Org.OData.Aggregation.V1.xml#L86)|[RollupType](#RollupType)|The service supports rollup hierarchies in a groupby transformation
+[PropertyRestrictions](Org.OData.Aggregation.V1.xml#L89)|Boolean|Only properties tagged as Groupable can be used in the groupby transformation, and only those tagged as Aggregatable can be used in the aggregate transformation
 
-## <a name="RollupType"></a>[RollupType](Org.OData.Aggregation.V1.xml#L92)
+## <a name="RollupType"></a>[RollupType](Org.OData.Aggregation.V1.xml#L95)
 The number of rollup operators allowed in a groupby transformation
 
 Member|Value|Description
 :-----|----:|:----------
-[None](Org.OData.Aggregation.V1.xml#L94)|0|No rollup support
-[SingleHierarchy](Org.OData.Aggregation.V1.xml#L97)|1|Only one rollup operator per groupby
-[MultipleHierarchies](Org.OData.Aggregation.V1.xml#L100)|2|Full rollup support
+[None](Org.OData.Aggregation.V1.xml#L97)|0|No rollup support
+[SingleHierarchy](Org.OData.Aggregation.V1.xml#L100)|1|Only one rollup operator per groupby
+[MultipleHierarchies](Org.OData.Aggregation.V1.xml#L103)|2|Full rollup support
 
-## <a name="RecursiveHierarchyType"></a>[RecursiveHierarchyType](Org.OData.Aggregation.V1.xml#L136)
-
-
-Property|Type|Description
-:-------|:---|:----------
-[NodeProperty](Org.OData.Aggregation.V1.xml#L137)|PropertyPath|Property holding the hierarchy node value
-[ParentNavigationProperty](Org.OData.Aggregation.V1.xml#L140)|NavigationPropertyPath|Property for navigating to the parent node
-[DistanceFromRootProperty](Org.OData.Aggregation.V1.xml#L143)|PropertyPath|Property holding the number of edges between the node and the root node
-[IsLeafProperty](Org.OData.Aggregation.V1.xml#L146)|PropertyPath|Property indicating whether the node is a leaf of the hierarchy
-
-## <a name="AvailableOnAggregatesType"></a>[AvailableOnAggregatesType](Org.OData.Aggregation.V1.xml#L201)
+## <a name="RecursiveHierarchyType"></a>[RecursiveHierarchyType](Org.OData.Aggregation.V1.xml#L139)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[RequiredProperties](Org.OData.Aggregation.V1.xml#L202)|\[PropertyPath\]|Properties required to apply this action or function
+[NodeProperty](Org.OData.Aggregation.V1.xml#L140)|PropertyPath|Property holding the hierarchy node value
+[ParentNavigationProperty](Org.OData.Aggregation.V1.xml#L143)|NavigationPropertyPath|Property for navigating to the parent node
+[DistanceFromRootProperty](Org.OData.Aggregation.V1.xml#L146)|PropertyPath|Property holding the number of edges between the node and the root node
+[IsLeafProperty](Org.OData.Aggregation.V1.xml#L149)|PropertyPath|Property indicating whether the node is a leaf of the hierarchy
+
+## <a name="AvailableOnAggregatesType"></a>[AvailableOnAggregatesType](Org.OData.Aggregation.V1.xml#L204)
+
+
+Property|Type|Description
+:-------|:---|:----------
+[RequiredProperties](Org.OData.Aggregation.V1.xml#L205)|\[PropertyPath\]|Properties required to apply this action or function
+
+## <a name="NavigationPropertyRestriction"></a>[NavigationPropertyRestriction](Org.OData.Aggregation.V1.xml#L210): [NavigationPropertyRestriction](Org.OData.Capabilities.V1.md#NavigationPropertyRestriction)
+Aggregation restrictions on a navigation path
+
+Property|Type|Description
+:-------|:---|:----------
+[ApplySupported](Org.OData.Aggregation.V1.xml#L212)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
+[CustomAggregates](Org.OData.Aggregation.V1.xml#L215)|\[String\]|Supported custom aggregates identified by their qualifier
+[GroupableProperties](Org.OData.Aggregation.V1.xml#L218)|\[String\]|Properties supported by the groupby transformation
+[AggregatableProperties](Org.OData.Aggregation.V1.xml#L221)|\[String\]|Properties supported by the aggregate transformation

--- a/vocabularies/Org.OData.Aggregation.V1.md
+++ b/vocabularies/Org.OData.Aggregation.V1.md
@@ -64,8 +64,8 @@ Property|Type|Description
 :-------|:---|:----------
 [RequiredProperties](Org.OData.Aggregation.V1.xml#L205)|\[PropertyPath\]|Properties required to apply this action or function
 
-## <a name="NavigationPropertyRestriction"></a>[NavigationPropertyRestriction](Org.OData.Aggregation.V1.xml#L210): [NavigationPropertyRestriction](Org.OData.Capabilities.V1.md#NavigationPropertyRestriction)
-Aggregation restrictions on a navigation path
+## <a name="NavigationPropertyAggregationCapabilities"></a>[NavigationPropertyAggregationCapabilities](Org.OData.Aggregation.V1.xml#L210): [NavigationPropertyRestriction](Org.OData.Capabilities.V1.md#NavigationPropertyRestriction)
+Aggregation capabilities on a navigation path
 
 This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.
 

--- a/vocabularies/Org.OData.Aggregation.V1.md
+++ b/vocabularies/Org.OData.Aggregation.V1.md
@@ -67,8 +67,6 @@ Property|Type|Description
 ## <a name="NavigationPropertyAggregationCapabilities"></a>[NavigationPropertyAggregationCapabilities](Org.OData.Aggregation.V1.xml#L210): [NavigationPropertyRestriction](Org.OData.Capabilities.V1.md#NavigationPropertyRestriction)
 Aggregation capabilities on a navigation path
 
-This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.
-
 Property|Type|Description
 :-------|:---|:----------
 [*NavigationProperty*](Org.OData.Capabilities.V1.xml#L250)|NavigationPropertyPath|Navigation properties can be navigated
@@ -88,7 +86,7 @@ Property|Type|Description
 [*DeleteRestrictions*](Org.OData.Capabilities.V1.xml#L296)|[DeleteRestrictionsType](Org.OData.Capabilities.V1.md#DeleteRestrictionsType)|Restrictions on delete operations
 [*OptimisticConcurrencyControl*](Org.OData.Capabilities.V1.xml#L299)|Boolean|Data modification (including insert) along this navigation property requires the use of ETags
 [*ReadRestrictions*](Org.OData.Capabilities.V1.xml#L303)|[ReadRestrictionsType](Org.OData.Capabilities.V1.md#ReadRestrictionsType)|Restrictions for retrieving entities
-[ApplySupported](Org.OData.Aggregation.V1.xml#L213)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
-[CustomAggregates](Org.OData.Aggregation.V1.xml#L216)|\[String\]|Supported custom aggregates identified by their qualifier
-[GroupableProperties](Org.OData.Aggregation.V1.xml#L219)|\[String\]|Properties supported by the groupby transformation
-[AggregatableProperties](Org.OData.Aggregation.V1.xml#L222)|\[String\]|Properties supported by the aggregate transformation
+[ApplySupported](Org.OData.Aggregation.V1.xml#L212)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
+[CustomAggregates](Org.OData.Aggregation.V1.xml#L215)|\[String\]|Supported custom aggregates identified by their qualifier
+[GroupableProperties](Org.OData.Aggregation.V1.xml#L218)|\[String\]|Properties supported by the groupby transformation
+[AggregatableProperties](Org.OData.Aggregation.V1.xml#L221)|\[String\]|Properties supported by the aggregate transformation

--- a/vocabularies/Org.OData.Aggregation.V1.md
+++ b/vocabularies/Org.OData.Aggregation.V1.md
@@ -67,9 +67,11 @@ Property|Type|Description
 ## <a name="NavigationPropertyRestriction"></a>[NavigationPropertyRestriction](Org.OData.Aggregation.V1.xml#L210): [NavigationPropertyRestriction](Org.OData.Capabilities.V1.md#NavigationPropertyRestriction)
 Aggregation restrictions on a navigation path
 
+This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type.
+
 Property|Type|Description
 :-------|:---|:----------
-[ApplySupported](Org.OData.Aggregation.V1.xml#L212)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
-[CustomAggregates](Org.OData.Aggregation.V1.xml#L215)|\[String\]|Supported custom aggregates identified by their qualifier
-[GroupableProperties](Org.OData.Aggregation.V1.xml#L218)|\[String\]|Properties supported by the groupby transformation
-[AggregatableProperties](Org.OData.Aggregation.V1.xml#L221)|\[String\]|Properties supported by the aggregate transformation
+[ApplySupported](Org.OData.Aggregation.V1.xml#L213)|[ApplySupportedType](#ApplySupportedType)|Support for $apply
+[CustomAggregates](Org.OData.Aggregation.V1.xml#L216)|\[String\]|Supported custom aggregates identified by their qualifier
+[GroupableProperties](Org.OData.Aggregation.V1.xml#L219)|\[String\]|Properties supported by the groupby transformation
+[AggregatableProperties](Org.OData.Aggregation.V1.xml#L222)|\[String\]|Properties supported by the aggregate transformation

--- a/vocabularies/Org.OData.Aggregation.V1.xml
+++ b/vocabularies/Org.OData.Aggregation.V1.xml
@@ -209,6 +209,7 @@
 
       <ComplexType Name="NavigationPropertyRestriction" BaseType="Capabilities.NavigationPropertyRestriction">
         <Annotation Term="Core.Description" String="Aggregation restrictions on a navigation path" />
+        <Annotation Term="Core.LongDescription" String="This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type." />
         <Property Name="ApplySupported" Type="Aggregation.ApplySupportedType">
           <Annotation Term="Core.Description" String="Support for $apply" />
         </Property>

--- a/vocabularies/Org.OData.Aggregation.V1.xml
+++ b/vocabularies/Org.OData.Aggregation.V1.xml
@@ -70,7 +70,7 @@
         </Collection>
       </Annotation>
 
-      <Term Name="ApplySupported" Type="Aggregation.ApplySupportedType" AppliesTo="EntityType ComplexType EntityContainer">
+      <Term Name="ApplySupported" Type="Aggregation.ApplySupportedType" AppliesTo="EntitySet ComplexType EntityContainer">
         <Annotation Term="Core.Description">
           <String>This structured type or entity container supports the $apply system query option</String>
         </Annotation>
@@ -113,7 +113,7 @@
         <Annotation Term="Core.Description" String="This property can be used in the aggregate transformation" />
       </Term>
 
-      <Term Name="CustomAggregate" Type="Edm.String" AppliesTo="EntityType ComplexType EntityContainer">
+      <Term Name="CustomAggregate" Type="Edm.String" AppliesTo="EntitySet ComplexType EntityContainer">
         <Annotation Term="Core.Description" String="Dynamic property that can be used in the aggregate transformation" />
         <Annotation Term="Core.LongDescription"
           String="This term MUST be applied with a Qualifier, the Qualifier value is the name of the dynamic property. The value of the annotation MUST be the qualified name of a primitive type. The aggregated values will be of that type." />
@@ -207,8 +207,8 @@
         </Property>
       </ComplexType>
 
-      <ComplexType Name="NavigationPropertyRestriction" BaseType="Capabilities.NavigationPropertyRestriction">
-        <Annotation Term="Core.Description" String="Aggregation restrictions on a navigation path" />
+      <ComplexType Name="NavigationPropertyAggregationCapabilities" BaseType="Capabilities.NavigationPropertyRestriction">
+        <Annotation Term="Core.Description" String="Aggregation capabilities on a navigation path" />
         <Annotation Term="Core.LongDescription" String="This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type." />
         <Property Name="ApplySupported" Type="Aggregation.ApplySupportedType">
           <Annotation Term="Core.Description" String="Support for $apply" />

--- a/vocabularies/Org.OData.Aggregation.V1.xml
+++ b/vocabularies/Org.OData.Aggregation.V1.xml
@@ -209,7 +209,6 @@
 
       <ComplexType Name="NavigationPropertyAggregationCapabilities" BaseType="Capabilities.NavigationPropertyRestriction">
         <Annotation Term="Core.Description" String="Aggregation capabilities on a navigation path" />
-        <Annotation Term="Core.LongDescription" String="This type derives from type NavigationPropertyRestriction in the Capabilities vocabulary and therefore additionally includes all properties from that type." />
         <Property Name="ApplySupported" Type="Aggregation.ApplySupportedType">
           <Annotation Term="Core.Description" String="Support for $apply" />
         </Property>

--- a/vocabularies/Org.OData.Aggregation.V1.xml
+++ b/vocabularies/Org.OData.Aggregation.V1.xml
@@ -42,6 +42,9 @@
   <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
     <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
   </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml">
+    <edmx:Include Namespace="Org.OData.Capabilities.V1" Alias="Capabilities" />
+  </edmx:Reference>
   <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Aggregation.V1" Alias="Aggregation">
       <Annotation Term="Core.Description">
@@ -204,6 +207,21 @@
         </Property>
       </ComplexType>
 
+      <ComplexType Name="NavigationPropertyRestriction" BaseType="Capabilities.NavigationPropertyRestriction">
+        <Annotation Term="Core.Description" String="Aggregation restrictions on a navigation path" />
+        <Property Name="ApplySupported" Type="Aggregation.ApplySupportedType">
+          <Annotation Term="Core.Description" String="Support for $apply" />
+        </Property>
+        <Property Name="CustomAggregates" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="Core.Description" String="Supported custom aggregates identified by their qualifier" />
+        </Property>
+        <Property Name="GroupableProperties" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="Core.Description" String="Properties supported by the groupby transformation" />
+        </Property>
+        <Property Name="AggregatableProperties" Type="Collection(Edm.String)" Nullable="false">
+          <Annotation Term="Core.Description" String="Properties supported by the aggregate transformation" />
+        </Property>
+      </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
This PR adds a derived complex type NavigationPropertyRestriction to restrict aggregation capabilities.

Example of its application:

Consider a service exposing files, mails and archived mails of a user via containment navigation properties originating from a singleton "Me". Both, mails and archived mails have the common "Mail" entity type that supports apply and includes an aggregatable property "Size" and a CustomAggregate annotation called "JunkRating". 

To express that the service does not support these two properties for archived mails, it annotates the "Me" singleton with this restriction:
```
<EntityContainer Name=“Default“>
  <Singleton Name=“Me“ … >
    <Annotation Term="Capabilities.NavigationRestrictions">
      <Record>
        <PropertyValue Property="RestrictedProperties">
          <Collection>
            <Record Type=”Aggregation.NavigationPropertyAggregationCapabilities”>
              <PropertyValue Property="NavigationProperty" NavigationPropertyPath="ArchivedMails" />
              <PropertyValue Property=”AggregatableProperties”>
                <Collection />  <!-- empty, in particular Size not mentioned -->
              </PropertyValue>
              <PropertyValue Property=”CustomAggregates”>
                <Collection />  <!-- empty, in particular JunkRating not mentioned -->
              </PropertyValue>
            </Record>
          </Collection>
        </PropertyValue>
      </Record>
    </Annotation>
  </Singleton>
</EntityContainer>
```