### PR TITLE
Avoid dependency on name of main branch

### DIFF
--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -661,7 +661,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
         !index.schema.$$namespace.startsWith("Org.OData.")
       ) {
         customFile =
-          "https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/" +
+          "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/" +
           customFile;
       }
     }

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -648,9 +648,6 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
     const url = index.namespaceUrl[np.qualifier];
 
     let customFile = "";
-    //TODO: not so :-)
-    if (modelElement.$Type == "com.sap.vocabularies.Common.v1.Experimental")
-      customFile = "Common.md";
     if (url) {
       // guess file name from reference URL
       const lastSegment = url.substring(url.lastIndexOf("/") + 1);
@@ -669,6 +666,9 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
       } else
         customFile += ".md";
     }
+    //TODO: not so :-)
+    if (modelElement.$Type == "com.sap.vocabularies.Common.v1.Experimental")
+      customFile = "Common.md";
 
     return (
       (modelElement.$Collection ? "\\[" : "") +

--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -648,13 +648,16 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
     const url = index.namespaceUrl[np.qualifier];
 
     let customFile = "";
+    //TODO: not so :-)
+    if (modelElement.$Type == "com.sap.vocabularies.Common.v1.Experimental")
+      customFile = "Common.md";
     if (url) {
       // guess file name from reference URL
       const lastSegment = url.substring(url.lastIndexOf("/") + 1);
       if (lastSegment.startsWith(index.namespace[np.qualifier] + "."))
-        customFile = index.namespace[np.qualifier] + ".md";
+        customFile = index.namespace[np.qualifier];
       else if (lastSegment.startsWith(index.alias[np.qualifier] + ".")) {
-        customFile = index.alias[np.qualifier] + ".md";
+        customFile = index.alias[np.qualifier];
       }
       if (
         customFile.startsWith("Org.OData.") &&
@@ -662,12 +665,10 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
       ) {
         customFile =
           "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/" +
-          customFile;
-      }
+          customFile + ".html";
+      } else
+        customFile += ".md";
     }
-    //TODO: not so :-)
-    if (modelElement.$Type == "com.sap.vocabularies.Common.v1.Experimental")
-      customFile = "Common.md";
 
     return (
       (modelElement.$Collection ? "\\[" : "") +

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -96,7 +96,7 @@ describe("Non-OASIS Vocabularies", function () {
       "",
       "Term|Type|Description",
       ":---|:---|:----------",
-      'Foo *(Deprecated)*|[Tag](https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Foo"></a>Use term `Foo` from the OASIS Core vocabulary instead',
+      'Foo *(Deprecated)*|[Tag](https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.html#Tag)|<a name="Foo"></a>Use term `Foo` from the OASIS Core vocabulary instead',
       'Bar|[Type](Another.md#Type)|<a name="Bar"></a>',
       "",
     ];

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -96,7 +96,7 @@ describe("Non-OASIS Vocabularies", function () {
       "",
       "Term|Type|Description",
       ":---|:---|:----------",
-      'Foo *(Deprecated)*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Foo"></a>Use term `Foo` from the OASIS Core vocabulary instead',
+      'Foo *(Deprecated)*|[Tag](https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Foo"></a>Use term `Foo` from the OASIS Core vocabulary instead',
       'Bar|[Type](Another.md#Type)|<a name="Bar"></a>',
       "",
     ];


### PR DESCRIPTION
The external type links in the vocabulary markdown files refer to the oasis-tcs/odata-vocabularies repository and contain the name of the main branch (currently `master`). Suggestion to replace them with links to github.io.