### PR TITLE
Nicely output validation errors in build script

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -4,6 +4,7 @@
 const csdl = require("odata-csdl");
 const lib = require("./csdl2markdown");
 const fs = require("fs");
+const colors = require("colors/safe");
 
 const vocabFolder = "./vocabularies/";
 const exampleFolder = "./examples/";
@@ -17,7 +18,20 @@ fs.readdirSync(vocabFolder)
     console.log(vocab + ".json");
 
     const xml = fs.readFileSync(vocabFolder + filename, "utf8");
-    const json = csdl.xml2json(xml, true);
+    let json;
+    try {
+      json = csdl.xml2json(xml, true);
+    } catch (e) {
+      console.error(
+        colors.red(
+          `${vocabFolder + filename}:${e.parser.line}:${e.parser.column}: ${
+            e.message
+          }`
+        )
+      );
+      process.exitCode = 1;
+      return;
+    }
 
     vocabs[filename] = json;
 
@@ -54,11 +68,20 @@ fs.readdirSync(exampleFolder)
     console.log(example + ".json");
 
     const xml = fs.readFileSync(exampleFolder + xmlfile, "utf8");
-    const json = csdl.xml2json(xml, false);
-    fs.writeFileSync(
-      exampleFolder + example + ".json",
-      JSON.stringify(json, null, 4)
-    );
+    try {
+      const json = csdl.xml2json(xml, false);
+      fs.writeFileSync(
+        exampleFolder + example + ".json",
+        JSON.stringify(json, null, 4)
+      );
+    } catch (e) {
+      console.error(
+        colors.red(
+          `${xmlfile}:${e.parser.line}:${e.parser.column}: ${e.message}`
+        )
+      );
+      process.exitCode = 1;
+    }
   });
 
 function omitLineNumbers(key, value) {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "dependencies": {
     "colors": "^1.4.0",
     "minimist": "^1.2.0",
-    "odata-csdl": "^0.2.9"
+    "odata-csdl": "^0.4"
   },
   "devDependencies": {
-    "c8": "^7.3.1",
-    "eslint": "^7.21.0",
-    "mocha": "^8.3.1"
+    "c8": "^7.10.0",
+    "eslint": "^8.4.0",
+    "mocha": "^9.1.3"
   },
   "scripts": {
     "build": "node lib/transform.js",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "main": "lib/csdl2markdown.js",
   "dependencies": {
+    "colors": "^1.4.0",
     "minimist": "^1.2.0",
     "odata-csdl": "^0.2.9"
   },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "main": "lib/csdl2markdown.js",
   "dependencies": {
     "colors": "^1.4.0",
-    "minimist": "^1.2.0",
-    "odata-csdl": "^0.4"
+    "minimist": "^1.2.5",
+    "odata-csdl": "^0.4.0"
   },
   "devDependencies": {
     "c8": "^7.10.0",


### PR DESCRIPTION
Fixes #173, together with https://github.com/oasis-tcs/odata-csdl-schemas/pull/50

Requires https://github.com/oasis-tcs/odata-csdl-schemas/pull/50 to be merged and npm package re-published