### PR TITLE
ErrorResponses: remove accidental nullability

### DIFF
--- a/vocabularies/Org.OData.Capabilities.V1.xml
+++ b/vocabularies/Org.OData.Capabilities.V1.xml
@@ -640,7 +640,7 @@ supported:
           <Annotation Term="Core.Description" String="A long description of the request" />
           <Annotation Term="Core.IsLanguageDependent" />
         </Property>
-        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)">
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
           <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
@@ -742,7 +742,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="A long description of the request" />
           <Annotation Term="Core.IsLanguageDependent" />
         </Property>
-        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)">
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
           <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
@@ -821,7 +821,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="A long description of the request" />
           <Annotation Term="Core.IsLanguageDependent" />
         </Property>
-        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)">
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
           <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
@@ -883,7 +883,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         <Property Name="CustomQueryOptions" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
           <Annotation Term="Core.Description" String="Supported or required custom query options" />
         </Property>
-        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)">
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
           <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
@@ -940,7 +940,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="A long description of the request" />
           <Annotation Term="Core.IsLanguageDependent" />
         </Property>
-        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)">
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
           <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>


### PR DESCRIPTION
A `null` entry in the `ErrorResponses` array would not be useful.