### PR TITLE
Derived types with undescribed properties

### DIFF
--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -441,7 +441,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
         p.$$filename = type.$$filename;
         p.$$parent = type;
         let desc = "";
-        for (let t = type; !desc; t = modelElement(t.$BaseType)) {
+        for (let t = type; t[name] && !desc; t = modelElement(t.$BaseType)) {
           desc = descriptionInTable(t[name]);
           if (!t.$BaseType) break;
         }

--- a/test/csdl2markdown.test.js
+++ b/test/csdl2markdown.test.js
@@ -454,7 +454,8 @@ describe("Edge cases", function () {
         DerivedType: {
           $Kind: "ComplexType",
           $BaseType: "Derived.v1.BaseType",
-          Value: {"$Type": "Edm.String"}
+          Value: {"$Type": "Edm.String"},
+          SelfExplanatory: {"$Type": "Edm.String"}
         },
       },
     };
@@ -482,6 +483,7 @@ describe("Edge cases", function () {
       "Property|Type|Description",
       ":-------|:---|:----------",
       "Value|String|The value",
+      "SelfExplanatory|String|",
       "",
     ];
     const markdown = lib.csdl2markdown(filename, vocabulary);


### PR DESCRIPTION
Without the change in `lib/csdl2markdown.js`, the changed test "Derived type" in `test/csdl2markdown.test.js` fails.