### PR TITLE
Allowed values for term properties

### DIFF
--- a/lib/csdl2markdown.js
+++ b/lib/csdl2markdown.js
@@ -579,6 +579,18 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
     const depr = deprecated(modelElement);
     const text = modelElement[voc.Core.Description];
     const long = modelElement[voc.Core.LongDescription];
+    let allowedValues = "";
+    const values = modelElement[voc.Validation.AllowedValues];
+    if (values)
+      values.forEach((v) => {
+        v.$$name = v.Value;
+        v.$$parent = modelElement;
+        allowedValues += "<br>- " + sourceLink(v) +
+            experimentalOrDeprecated(v);
+        const allowedValue = descriptionInTable(v);
+        if (allowedValue) allowedValues += ": " + allowedValue;
+      });
+
     const example = modelElement[voc.Core.Example];
     if (example) {
       example.$$name = "Example";
@@ -590,6 +602,7 @@ module.exports.csdl2markdown = function (filename, csdl, referenced = {}) {
       : escape(text) +
           (example ? " (" + sourceLink(example) + ")" : "") +
           (long ? "<br>" + escape(long) : "") +
+          (allowedValues ? "<br>*Allowed values:*" + escape(allowedValues) : "") +
           applicableTermsList(
             modelElement[voc.Validation.ApplicableTerms] || []
           ) +


### PR DESCRIPTION
Show `AllowedValues` for term properties in Markdown:
```xml
<ComplexType Name="HierarchyType">
  <Property Name="DrillState" Type="Edm.String" Nullable="true">
    <Annotation Term="Core.Description" String="Drill state of an entry" />
    <Annotation Term="Validation.AllowedValues">
      <Collection>
        <Record>
          <PropertyValue Property="Value" String="expanded" />
          <Annotation Term="Core.Description" String="The entry precedes entries from deeper aggregation levels" />
        </Record>
        <Record>
          <PropertyValue Property="Value" String="collapsed" />
          <Annotation Term="Core.Description" String="The entry belongs to the highest non-expanded aggregation level, but not the deepest" />
        </Record>
        <Record>
          <PropertyValue Property="Value" String="leaf" />
          <Annotation Term="Core.Description" String="The entry belongs to the deepest aggregation level" />
        </Record>
      </Collection>
    </Annotation>
  </Property>
  ...
</ComplexType>