### PR TITLE
Allow installing as dependency

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build with pandoc
         run: |
           npm ci
-          npm run pages "OASIS OData TC"
+          npm run pages
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -24,9 +24,10 @@ function file(dir, title, filename) {
 
 function directory(dir, title) {
   if (fs.existsSync(dir)) {
-    fs.cpSync(`${dir}`, `_site/${dir}`, {
-      recursive: true,
-    });
+    if (dir !== ".")
+      fs.cpSync(`${dir}`, `_site/${dir}`, {
+        recursive: true,
+      });
     fs.readdirSync(dir)
       .filter((fn) => fn.endsWith(".md"))
       .forEach(function (filename) {
@@ -39,7 +40,7 @@ fs.cpSync(`${__dirname}/../assets/styles`, `_site/styles`, {
   recursive: true,
 });
 
-file(".", "", "README.md");
+directory(".", "");
 directory("docs", "Documents");
 directory("examples", "Examples");
 directory("vocabularies", "Vocabularies");

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -8,7 +8,7 @@ function file(dir, title, filename) {
   console.log(`${dir}/${filename}`);
   pandoc(
     {
-      stdin: fs.createReadStream(`${__dirname}/../${dir}/${filename}`),
+      stdin: fs.createReadStream(`${dir}/${filename}`),
       stdout: fs.createWriteStream(
         `_site/${dir}/${filename === "README.md" ? "index.html" : filename.replace(/\.md$/, ".html")}`,
       ),
@@ -23,11 +23,11 @@ function file(dir, title, filename) {
 }
 
 function directory(dir, title) {
-  if (fs.existsSync(`${__dirname}/../${dir}`)) {
-    fs.cpSync(`${__dirname}/../${dir}`, `_site/${dir}`, {
+  if (fs.existsSync(dir)) {
+    fs.cpSync(`${dir}`, `_site/${dir}`, {
       recursive: true,
     });
-    fs.readdirSync(`${__dirname}/../${dir}`)
+    fs.readdirSync(dir)
       .filter((fn) => fn.endsWith(".md"))
       .forEach(function (filename) {
         file(dir, title, filename);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "node lib/transform.js",
-    "pages": "node lib/pages.js",
+    "pages": "node lib/pages.js \"OASIS OData TC\"",
     "test": "c8 -r html -r text mocha",
     "watch": "mocha --watch"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "git+https://github.com/oasis-tcs/odata-vocabularies.git"
   },
   "files": [
-    "lib/*"
+    "lib/*",
+    "assets/*"
   ],
   "bin": {
     "odata-vocab2md": "lib/cli.js"


### PR DESCRIPTION
Without these changes SAP/odata-vocabularies cannot use oasis-tcs/odata-vocabularies as a dependency.