### PR TITLE
Clarification regarding Validation.Pattern

### DIFF
--- a/vocabularies/Org.OData.Validation.V1.json
+++ b/vocabularies/Org.OData.Validation.V1.json
@@ -34,7 +34,8 @@
                 "Parameter",
                 "Term"
             ],
-            "@Core.Description": "The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.",
+            "@Core.Description": "The pattern that a string property, parameter, or term must match in its entirety",
+            "@Core.LongDescription": "This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.",
             "@Core.RequiresType": "Edm.String"
         },
         "Minimum": {

--- a/vocabularies/Org.OData.Validation.V1.md
+++ b/vocabularies/Org.OData.Validation.V1.md
@@ -8,53 +8,53 @@ Terms describing validation rules
 
 Term|Type|Description
 :---|:---|:----------
-[Pattern](./Org.OData.Validation.V1.xml#L67:~:text=<Term%20Name="-,Pattern,-")|String|<a name="Pattern"></a>The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.
-[Minimum](./Org.OData.Validation.V1.xml#L72:~:text=<Term%20Name="-,Minimum,-")|PrimitiveType|<a name="Minimum"></a>Minimum value that a property, parameter, or term can have.<br>Can be annotated with:<ul><li>[Exclusive](#Exclusive)</li></ul>
-[Maximum](./Org.OData.Validation.V1.xml#L81:~:text=<Term%20Name="-,Maximum,-")|PrimitiveType|<a name="Maximum"></a>Maximum value that a property, parameter, or term can have.<br>Can be annotated with:<ul><li>[Exclusive](#Exclusive)</li></ul>
-[Exclusive](./Org.OData.Validation.V1.xml#L90:~:text=<Term%20Name="-,Exclusive,-")|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Exclusive"></a>Tags a Minimum or Maximum as exclusive, i.e. an open interval boundary.
-[AllowedValues](./Org.OData.Validation.V1.xml#L94:~:text=<Term%20Name="-,AllowedValues,-")|\[[AllowedValue](#AllowedValue)\]|<a name="AllowedValues"></a>A collection of valid values for the annotated property, parameter, or type definition
-[MultipleOf](./Org.OData.Validation.V1.xml#L108:~:text=<Term%20Name="-,MultipleOf,-")|Decimal|<a name="MultipleOf"></a>The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds.
-[Constraint](./Org.OData.Validation.V1.xml#L112:~:text=<Term%20Name="-,Constraint,-")|[ConstraintType](#ConstraintType)|<a name="Constraint"></a>Condition that the annotation target has to fulfill
-[ItemsOf](./Org.OData.Validation.V1.xml#L125:~:text=<Term%20Name="-,ItemsOf,-")|\[[ItemsOfType](#ItemsOfType)\]|<a name="ItemsOf"></a>A list of constraints describing that entities related via one navigation property MUST also be related via another, collection-valued navigation property. The same `path` value MUST NOT occur more than once.<br>Example: entity type `Customer` has navigation properties `AllOrders`, `OpenOrders`, and `ClosedOrders`. The term allows to express that items of `OpenOrders` and `ClosedOrders` are also items of the `AllOrders` navigation property, even though they are defined in an `Orders` entity set.
-[OpenPropertyTypeConstraint](./Org.OData.Validation.V1.xml#L143:~:text=<Term%20Name="-,OpenPropertyTypeConstraint,-")|\[[SingleOrCollectionType](#SingleOrCollectionType)\]|<a name="OpenPropertyTypeConstraint"></a>Dynamic properties added to the annotated open structured type are restricted to the listed types.
-[DerivedTypeConstraint](./Org.OData.Validation.V1.xml#L147:~:text=<Term%20Name="-,DerivedTypeConstraint,-")|\[[SingleOrCollectionType](#SingleOrCollectionType)\]|<a name="DerivedTypeConstraint"></a>Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection.<br>This allows restricting values to certain sub-trees of an inheritance hierarchy, including hierarchies starting at the [Built-In Abstract Types](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#sec_BuiltInAbstractTypes). Types listed in this collection are ignored if they are not derived from the declared type of the annotated model element or would not be allowed as declared type of the annotated model element.<br/> When applied to a collection-valued element, this annotation specifies the types allowed for members of the collection without mentioning the `Collection()` wrapper. The SingleOrCollectionType may only include the `Collection()` wrapper if the annotation is applied to an element with declared type `Edm.Untyped`.
-[AllowedTerms](./Org.OData.Validation.V1.xml#L166:~:text=<Term%20Name="-,AllowedTerms,-")|\[[QualifiedTermName](Org.OData.Core.V1.md#QualifiedTermName)\]|<a name="AllowedTerms"></a>Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path.<br>The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed.
-[ApplicableTerms](./Org.OData.Validation.V1.xml#L172:~:text=<Term%20Name="-,ApplicableTerms,-")|\[[QualifiedTermName](Org.OData.Core.V1.md#QualifiedTermName)\]|<a name="ApplicableTerms"></a>Names of specific terms that are applicable and may be applied in the current context. This annotation does not restrict the use of other terms.
-[MaxItems](./Org.OData.Validation.V1.xml#L176:~:text=<Term%20Name="-,MaxItems,-")|Int64|<a name="MaxItems"></a>The annotated collection must have at most the specified number of items.
-[MinItems](./Org.OData.Validation.V1.xml#L180:~:text=<Term%20Name="-,MinItems,-")|Int64|<a name="MinItems"></a>The annotated collection must have at least the specified number of items.
+[Pattern](./Org.OData.Validation.V1.xml#L67:~:text=<Term%20Name="-,Pattern,-")|String|<a name="Pattern"></a>The pattern that a string property, parameter, or term must match in its entirety<br>This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.
+[Minimum](./Org.OData.Validation.V1.xml#L75:~:text=<Term%20Name="-,Minimum,-")|PrimitiveType|<a name="Minimum"></a>Minimum value that a property, parameter, or term can have.<br>Can be annotated with:<ul><li>[Exclusive](#Exclusive)</li></ul>
+[Maximum](./Org.OData.Validation.V1.xml#L84:~:text=<Term%20Name="-,Maximum,-")|PrimitiveType|<a name="Maximum"></a>Maximum value that a property, parameter, or term can have.<br>Can be annotated with:<ul><li>[Exclusive](#Exclusive)</li></ul>
+[Exclusive](./Org.OData.Validation.V1.xml#L93:~:text=<Term%20Name="-,Exclusive,-")|[Tag](Org.OData.Core.V1.md#Tag)|<a name="Exclusive"></a>Tags a Minimum or Maximum as exclusive, i.e. an open interval boundary.
+[AllowedValues](./Org.OData.Validation.V1.xml#L97:~:text=<Term%20Name="-,AllowedValues,-")|\[[AllowedValue](#AllowedValue)\]|<a name="AllowedValues"></a>A collection of valid values for the annotated property, parameter, or type definition
+[MultipleOf](./Org.OData.Validation.V1.xml#L111:~:text=<Term%20Name="-,MultipleOf,-")|Decimal|<a name="MultipleOf"></a>The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds.
+[Constraint](./Org.OData.Validation.V1.xml#L115:~:text=<Term%20Name="-,Constraint,-")|[ConstraintType](#ConstraintType)|<a name="Constraint"></a>Condition that the annotation target has to fulfill
+[ItemsOf](./Org.OData.Validation.V1.xml#L128:~:text=<Term%20Name="-,ItemsOf,-")|\[[ItemsOfType](#ItemsOfType)\]|<a name="ItemsOf"></a>A list of constraints describing that entities related via one navigation property MUST also be related via another, collection-valued navigation property. The same `path` value MUST NOT occur more than once.<br>Example: entity type `Customer` has navigation properties `AllOrders`, `OpenOrders`, and `ClosedOrders`. The term allows to express that items of `OpenOrders` and `ClosedOrders` are also items of the `AllOrders` navigation property, even though they are defined in an `Orders` entity set.
+[OpenPropertyTypeConstraint](./Org.OData.Validation.V1.xml#L146:~:text=<Term%20Name="-,OpenPropertyTypeConstraint,-")|\[[SingleOrCollectionType](#SingleOrCollectionType)\]|<a name="OpenPropertyTypeConstraint"></a>Dynamic properties added to the annotated open structured type are restricted to the listed types.
+[DerivedTypeConstraint](./Org.OData.Validation.V1.xml#L150:~:text=<Term%20Name="-,DerivedTypeConstraint,-")|\[[SingleOrCollectionType](#SingleOrCollectionType)\]|<a name="DerivedTypeConstraint"></a>Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection.<br>This allows restricting values to certain sub-trees of an inheritance hierarchy, including hierarchies starting at the [Built-In Abstract Types](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#sec_BuiltInAbstractTypes). Types listed in this collection are ignored if they are not derived from the declared type of the annotated model element or would not be allowed as declared type of the annotated model element.<br/> When applied to a collection-valued element, this annotation specifies the types allowed for members of the collection without mentioning the `Collection()` wrapper. The SingleOrCollectionType may only include the `Collection()` wrapper if the annotation is applied to an element with declared type `Edm.Untyped`.
+[AllowedTerms](./Org.OData.Validation.V1.xml#L169:~:text=<Term%20Name="-,AllowedTerms,-")|\[[QualifiedTermName](Org.OData.Core.V1.md#QualifiedTermName)\]|<a name="AllowedTerms"></a>Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path.<br>The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed.
+[ApplicableTerms](./Org.OData.Validation.V1.xml#L175:~:text=<Term%20Name="-,ApplicableTerms,-")|\[[QualifiedTermName](Org.OData.Core.V1.md#QualifiedTermName)\]|<a name="ApplicableTerms"></a>Names of specific terms that are applicable and may be applied in the current context. This annotation does not restrict the use of other terms.
+[MaxItems](./Org.OData.Validation.V1.xml#L179:~:text=<Term%20Name="-,MaxItems,-")|Int64|<a name="MaxItems"></a>The annotated collection must have at most the specified number of items.
+[MinItems](./Org.OData.Validation.V1.xml#L183:~:text=<Term%20Name="-,MinItems,-")|Int64|<a name="MinItems"></a>The annotated collection must have at least the specified number of items.
 
 <a name="AllowedValue"></a>
-## [AllowedValue](./Org.OData.Validation.V1.xml#L97:~:text=<ComplexType%20Name="-,AllowedValue,-")
+## [AllowedValue](./Org.OData.Validation.V1.xml#L100:~:text=<ComplexType%20Name="-,AllowedValue,-")
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Value](./Org.OData.Validation.V1.xml#L103:~:text=<ComplexType%20Name="-,AllowedValue,-")|PrimitiveType?|An allowed value for the property, parameter, or type definition
+[Value](./Org.OData.Validation.V1.xml#L106:~:text=<ComplexType%20Name="-,AllowedValue,-")|PrimitiveType?|An allowed value for the property, parameter, or type definition
 
 **Applicable Annotation Terms:**
 
 - [SymbolicName](Org.OData.Core.V1.md#SymbolicName)
 
 <a name="ConstraintType"></a>
-## [ConstraintType](./Org.OData.Validation.V1.xml#L115:~:text=<ComplexType%20Name="-,ConstraintType,-")
+## [ConstraintType](./Org.OData.Validation.V1.xml#L118:~:text=<ComplexType%20Name="-,ConstraintType,-")
 
 
 Property|Type|Description
 :-------|:---|:----------
-[FailureMessage](./Org.OData.Validation.V1.xml#L116:~:text=<ComplexType%20Name="-,ConstraintType,-")|String?|Human-readable message that can be shown to end users if the constraint is not fulfilled
-[Condition](./Org.OData.Validation.V1.xml#L120:~:text=<ComplexType%20Name="-,ConstraintType,-")|Boolean|Value MUST be a dynamic expression that evaluates to true if and only if the constraint is fulfilled
+[FailureMessage](./Org.OData.Validation.V1.xml#L119:~:text=<ComplexType%20Name="-,ConstraintType,-")|String?|Human-readable message that can be shown to end users if the constraint is not fulfilled
+[Condition](./Org.OData.Validation.V1.xml#L123:~:text=<ComplexType%20Name="-,ConstraintType,-")|Boolean|Value MUST be a dynamic expression that evaluates to true if and only if the constraint is fulfilled
 
 <a name="ItemsOfType"></a>
-## [ItemsOfType](./Org.OData.Validation.V1.xml#L133:~:text=<ComplexType%20Name="-,ItemsOfType,-")
+## [ItemsOfType](./Org.OData.Validation.V1.xml#L136:~:text=<ComplexType%20Name="-,ItemsOfType,-")
 Entities related via the single- or collection-valued navigation property identified by `path` are also related via the collection-valued navigation property identified by `target`.
 
 Property|Type|Description
 :-------|:---|:----------
-[path](./Org.OData.Validation.V1.xml#L135:~:text=<ComplexType%20Name="-,ItemsOfType,-")|NavigationPropertyPath|A path to a single- or collection-valued navigation property
-[target](./Org.OData.Validation.V1.xml#L138:~:text=<ComplexType%20Name="-,ItemsOfType,-")|NavigationPropertyPath|A path to a collection-valued navigation property
+[path](./Org.OData.Validation.V1.xml#L138:~:text=<ComplexType%20Name="-,ItemsOfType,-")|NavigationPropertyPath|A path to a single- or collection-valued navigation property
+[target](./Org.OData.Validation.V1.xml#L141:~:text=<ComplexType%20Name="-,ItemsOfType,-")|NavigationPropertyPath|A path to a collection-valued navigation property
 
 <a name="SingleOrCollectionType"></a>
-## [SingleOrCollectionType](./Org.OData.Validation.V1.xml#L162:~:text=<TypeDefinition%20Name="-,SingleOrCollectionType,-")
+## [SingleOrCollectionType](./Org.OData.Validation.V1.xml#L165:~:text=<TypeDefinition%20Name="-,SingleOrCollectionType,-")
 **Type:** String
 
 The qualified name of a type in scope, optionally wrapped in `Collection()` to denote a collection of instances of the type

--- a/vocabularies/Org.OData.Validation.V1.xml
+++ b/vocabularies/Org.OData.Validation.V1.xml
@@ -65,7 +65,10 @@
       </Annotation>
 
       <Term Name="Pattern" Type="Edm.String" Nullable="false" AppliesTo="Property Parameter Term">
-        <Annotation Term="Core.Description" String="The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect." />
+        <Annotation Term="Core.Description" String="The pattern that a string property, parameter, or term must match in its entirety" />
+        <Annotation Term="Core.LongDescription">
+          <String>This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect.</String>
+        </Annotation>
         <Annotation Term="Core.RequiresType" String="Edm.String" />
       </Term>
 


### PR DESCRIPTION
The annotated property must match the regular expression _in its entirety_, because a regular expression like `\d+` (one or more digits) is also matched by the string `7up`, just not in its entirety.