### PR TITLE
Add Core.IsDelta term for parameters/return types that are represented as deltas

### DIFF
--- a/vocabularies/Org.OData.Core.V1.json
+++ b/vocabularies/Org.OData.Core.V1.json
@@ -748,7 +748,7 @@
                 "Parameter"
             ],
             "@Core.Description": "The annotated Action or Function Parameter or Return Type is represented as a Delta payload",
-            "@Core.LongDescription": "The parameter or result is represented as a delta payload, which may contain deleted entities and changes to related entities according to the format-specific delta representation."
+            "@Core.LongDescription": "The parameter or result is represented as a delta payload, which may include deleted entries as well as changes to related \n          entities and relationships, according to the format-specific delta representation."
         }
     }
 }

--- a/vocabularies/Org.OData.Core.V1.json
+++ b/vocabularies/Org.OData.Core.V1.json
@@ -738,6 +738,17 @@
             ],
             "@Core.Description": "Instances of a type are annotated with this tag if they have no common structure in a given response payload",
             "@Core.LongDescription": "The select-list of a context URL MUST be `(@Core.AnyStructure)` if it would otherwise be empty,\n          but this instance annotation SHOULD be omitted from the response value."
+        },
+        "IsDelta": {
+            "$Kind": "Term",
+            "$Type": "Core.Tag",
+            "$DefaultValue": true,
+            "$AppliesTo": [
+                "ReturnType",
+                "Parameter"
+            ],
+            "@Core.Description": "The annotated Action or Function Parameter or Return Type is represented as a Delta payload",
+            "@Core.LongDescription": "The parameter or result is represented as a delta payload, which may contain deleted entities and changes to related entities according to the format-specific delta representation."
         }
     }
 }

--- a/vocabularies/Org.OData.Core.V1.md
+++ b/vocabularies/Org.OData.Core.V1.md
@@ -51,6 +51,7 @@ Term|Type|Description
 [SymbolicName](Org.OData.Core.V1.xml#L536)|[SimpleIdentifier](#SimpleIdentifier)|<a name="SymbolicName"></a>A symbolic name for a model element
 [GeometryFeature](Org.OData.Core.V1.xml#L545)|[GeometryFeatureType?](#GeometryFeatureType)|<a name="GeometryFeature"></a>A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing
 [AnyStructure](Org.OData.Core.V1.xml#L561)|[Tag](#Tag)|<a name="AnyStructure"></a>Instances of a type are annotated with this tag if they have no common structure in a given response payload<br>The select-list of a context URL MUST be `(@Core.AnyStructure)` if it would otherwise be empty, but this instance annotation SHOULD be omitted from the response value.
+[IsDelta](Org.OData.Core.V1.xml#L569)|[Tag](#Tag)|<a name="IsDelta"></a>The annotated Action or Function Parameter or Return Type is represented as a Delta payload<br>The parameter or result is represented as a delta payload, which may contain deleted entities and changes to related entities according to the format-specific delta representation.
 
 <a name="RevisionType"></a>
 ## [RevisionType](Org.OData.Core.V1.xml#L80)

--- a/vocabularies/Org.OData.Core.V1.md
+++ b/vocabularies/Org.OData.Core.V1.md
@@ -51,7 +51,7 @@ Term|Type|Description
 [SymbolicName](Org.OData.Core.V1.xml#L536)|[SimpleIdentifier](#SimpleIdentifier)|<a name="SymbolicName"></a>A symbolic name for a model element
 [GeometryFeature](Org.OData.Core.V1.xml#L545)|[GeometryFeatureType?](#GeometryFeatureType)|<a name="GeometryFeature"></a>A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing
 [AnyStructure](Org.OData.Core.V1.xml#L561)|[Tag](#Tag)|<a name="AnyStructure"></a>Instances of a type are annotated with this tag if they have no common structure in a given response payload<br>The select-list of a context URL MUST be `(@Core.AnyStructure)` if it would otherwise be empty, but this instance annotation SHOULD be omitted from the response value.
-[IsDelta](Org.OData.Core.V1.xml#L569)|[Tag](#Tag)|<a name="IsDelta"></a>The annotated Action or Function Parameter or Return Type is represented as a Delta payload<br>The parameter or result is represented as a delta payload, which may contain deleted entities and changes to related entities according to the format-specific delta representation.
+[IsDelta](Org.OData.Core.V1.xml#L569)|[Tag](#Tag)|<a name="IsDelta"></a>The annotated Action or Function Parameter or Return Type is represented as a Delta payload<br>The parameter or result is represented as a delta payload, which may include deleted entries as well as changes to related entities and relationships, according to the format-specific delta representation.
 
 <a name="RevisionType"></a>
 ## [RevisionType](Org.OData.Core.V1.xml#L80)

--- a/vocabularies/Org.OData.Core.V1.xml
+++ b/vocabularies/Org.OData.Core.V1.xml
@@ -566,6 +566,14 @@ Any simple identifier | Any type listed in `Validation.OpenPropertyTypeConstrain
         </Annotation>
       </Term>
 
+      <Term Name="IsDelta" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="ReturnType Parameter">
+        <Annotation Term="Core.Description" String="The annotated Action or Function Parameter or Return Type is represented as a Delta payload" />
+        <Annotation Term="Core.LongDescription">
+          <String>The parameter or result is represented as a delta payload, which may include deleted entries as well as changes to related 
+          entities and relationships, according to the format-specific delta representation.</String>
+        </Annotation>
+      </Term>
+
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>


### PR DESCRIPTION
Fixes https://github.com/oasis-tcs/odata-specs/issues/348.

Defines the Core.IsDelta term that can be applied to an action or function parameter or return type to indicate that the parameter or return type is represented as a delta payload.