### PR TITLE
Add Node 22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Node 22 is now current, Node 20 is active LTS, see https://github.com/nodejs/release?tab=readme-ov-file#release-schedule