### PR TITLE
Avoid flickering when navigating from dark mode to dark mode

### DIFF
--- a/assets/darkmode.html
+++ b/assets/darkmode.html
@@ -1,33 +1,32 @@
 <script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function () {
-    function darkmode_auto() {
-      if (darkmode_switch.value === "auto") {
-        if (darkmode_query.matches) document.documentElement.classList.add("darkmode");
-        else document.documentElement.classList.remove("darkmode");
-      }
+  function darkmode_auto() {
+    if (darkmode_switch.value === "auto") {
+      if (darkmode_query.matches)
+        document.documentElement.classList.add("darkmode");
+      else document.documentElement.classList.remove("darkmode");
     }
+  }
 
-    function darkmode_manual() {
-      localStorage.setItem("odata-vocabularies/darkmode", darkmode_switch.value);
-      switch (darkmode_switch.value) {
-        case "off":
-          document.documentElement.classList.remove("darkmode");
-          break;
-        case "on":
-          document.documentElement.classList.add("darkmode");
-          break;
-        case "auto":
-          darkmode_auto();
-          break;
-      }
+  function darkmode_manual() {
+    localStorage.setItem("odata-vocabularies/darkmode", darkmode_switch.value);
+    switch (darkmode_switch.value) {
+      case "off":
+        document.documentElement.classList.remove("darkmode");
+        break;
+      case "on":
+        document.documentElement.classList.add("darkmode");
+        break;
+      case "auto":
+        darkmode_auto();
+        break;
     }
+  }
 
-    const darkmode_query = matchMedia("(prefers-color-scheme: dark)");
-    darkmode_query.addEventListener("change", darkmode_auto);
-    const darkmode_switch = document.querySelector("#darkmode select");
-    darkmode_switch.value =
-      localStorage.getItem("odata-vocabularies/darkmode") || "off";
-    darkmode_switch.addEventListener("change", darkmode_manual);
-    darkmode_manual();
-  });
+  const darkmode_query = matchMedia("(prefers-color-scheme: dark)");
+  darkmode_query.addEventListener("change", darkmode_auto);
+  const darkmode_switch = document.querySelector("#darkmode select");
+  darkmode_switch.value =
+    localStorage.getItem("odata-vocabularies/darkmode") || "off";
+  darkmode_switch.addEventListener("change", darkmode_manual);
+  darkmode_manual();
 </script>

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -33,7 +33,7 @@ function file(dir, title, filename) {
   </select>
 </aside>`,
       ],
-      "-H": `${__dirname}/../assets/darkmode.html`,
+      "-A": `${__dirname}/../assets/darkmode.html`,
       "--template": "assets/template",
     },
   );


### PR DESCRIPTION
When navigating between pages on https://oasis-tcs.github.io/odata-vocabularies in dark mode, the target page is briefly rendered in light mode and then switched to dark mode, causing unwanted flickering.